### PR TITLE
Fix app state after closing and reopening

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/MainActivity.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/MainActivity.kt
@@ -4,14 +4,24 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.flow.first
 import pe.net.libre.mixtapehaven.data.preferences.DataStoreManager
 import pe.net.libre.mixtapehaven.data.repository.ConnectionRepository
 import pe.net.libre.mixtapehaven.data.repository.MediaRepository
 import pe.net.libre.mixtapehaven.ui.navigation.NavGraph
+import pe.net.libre.mixtapehaven.ui.navigation.Screen
 import pe.net.libre.mixtapehaven.ui.onboarding.OnboardingViewModel
 import pe.net.libre.mixtapehaven.ui.theme.DeepSpaceBlack
 import pe.net.libre.mixtapehaven.ui.theme.MixtapeHavenTheme
@@ -33,12 +43,39 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = DeepSpaceBlack
                 ) {
-                    val navController = rememberNavController()
-                    NavGraph(
-                        navController = navController,
-                        onboardingViewModel = onboardingViewModel,
-                        mediaRepository = mediaRepository
-                    )
+                    var startDestination by remember { mutableStateOf<String?>(null) }
+
+                    // Check if user is already logged in
+                    LaunchedEffect(Unit) {
+                        val accessToken = dataStoreManager.accessToken.first()
+                        val serverUrl = dataStoreManager.serverUrl.first()
+
+                        // If we have both token and server URL, user is logged in
+                        startDestination = if (!accessToken.isNullOrEmpty() && !serverUrl.isNullOrEmpty()) {
+                            Screen.Home.route
+                        } else {
+                            Screen.Onboarding.route
+                        }
+                    }
+
+                    // Show loading indicator while checking auth status
+                    if (startDestination == null) {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    } else {
+                        val navController = rememberNavController()
+                        NavGraph(
+                            navController = navController,
+                            onboardingViewModel = onboardingViewModel,
+                            mediaRepository = mediaRepository,
+                            connectionRepository = connectionRepository,
+                            startDestination = startDestination!!
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/HomeScreen.kt
@@ -54,14 +54,16 @@ fun HomeScreen(
     mediaRepository: MediaRepository,
     onNavigateToAllAlbums: () -> Unit = {},
     onNavigateToAllArtists: () -> Unit = {},
-    onNavigateToAllSongs: () -> Unit = {}
+    onNavigateToAllSongs: () -> Unit = {},
+    onLogout: () -> Unit = {}
 ) {
     val viewModel: HomeViewModel = viewModel {
         HomeViewModel(
             mediaRepository = mediaRepository,
             onNavigateToAllAlbums = onNavigateToAllAlbums,
             onNavigateToAllArtists = onNavigateToAllArtists,
-            onNavigateToAllSongs = onNavigateToAllSongs
+            onNavigateToAllSongs = onNavigateToAllSongs,
+            onLogout = onLogout
         )
     }
     val uiState by viewModel.uiState.collectAsState()

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/HomeViewModel.kt
@@ -16,7 +16,8 @@ class HomeViewModel(
     private val mediaRepository: MediaRepository,
     private val onNavigateToAllAlbums: () -> Unit = {},
     private val onNavigateToAllArtists: () -> Unit = {},
-    private val onNavigateToAllSongs: () -> Unit = {}
+    private val onNavigateToAllSongs: () -> Unit = {},
+    private val onLogout: () -> Unit = {}
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -103,7 +104,8 @@ class HomeViewModel(
     }
 
     fun onProfileClick() {
-        // TODO: Open profile menu
+        // Trigger logout
+        onLogout()
     }
 }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/NavGraph.kt
@@ -1,9 +1,12 @@
 package pe.net.libre.mixtapehaven.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.data.repository.ConnectionRepository
 import pe.net.libre.mixtapehaven.data.repository.MediaRepository
 import pe.net.libre.mixtapehaven.ui.home.HomeScreen
 import pe.net.libre.mixtapehaven.ui.home.detail.AllAlbumsScreen
@@ -26,11 +29,15 @@ sealed class Screen(val route: String) {
 fun NavGraph(
     navController: NavHostController,
     onboardingViewModel: OnboardingViewModel,
-    mediaRepository: MediaRepository
+    mediaRepository: MediaRepository,
+    connectionRepository: ConnectionRepository,
+    startDestination: String = Screen.Onboarding.route
 ) {
+    val coroutineScope = rememberCoroutineScope()
+
     NavHost(
         navController = navController,
-        startDestination = Screen.Onboarding.route
+        startDestination = startDestination
     ) {
         composable(Screen.Onboarding.route) {
             OnboardingScreen(
@@ -57,6 +64,14 @@ fun NavGraph(
                 },
                 onNavigateToAllSongs = {
                     navController.navigate(Screen.AllSongs.route)
+                },
+                onLogout = {
+                    coroutineScope.launch {
+                        connectionRepository.clearConnection()
+                        navController.navigate(Screen.Onboarding.route) {
+                            popUpTo(0) { inclusive = true }
+                        }
+                    }
                 }
             )
         }


### PR DESCRIPTION
This commit fixes the issue where users had to log in every time they opened the app.

Changes:
- MainActivity now checks for stored credentials on startup and navigates directly to Home screen if user is already logged in
- Added dynamic start destination to NavGraph based on authentication status
- Implemented logout functionality accessible via the profile button on Home screen
- Added loading indicator while checking authentication status on app startup

Technical details:
- Uses DataStore to check for existing access token and server URL
- NavGraph accepts a configurable start destination parameter
- Logout clears all stored credentials via ConnectionRepository and navigates back to Onboarding screen