### PR TITLE
Enable game start from all screens

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/detail/AllSongsScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/detail/AllSongsScreen.kt
@@ -34,7 +34,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import pe.net.libre.mixtapehaven.data.playback.PlaybackManager
 import pe.net.libre.mixtapehaven.data.repository.MediaRepository
+import pe.net.libre.mixtapehaven.ui.home.components.NowPlayingBar
 import pe.net.libre.mixtapehaven.ui.home.components.SongListItem
 import pe.net.libre.mixtapehaven.ui.theme.CyberNeonBlue
 import pe.net.libre.mixtapehaven.ui.theme.DeepSpaceBlack
@@ -44,14 +46,19 @@ import pe.net.libre.mixtapehaven.ui.theme.LunarWhite
 @Composable
 fun AllSongsScreen(
     mediaRepository: MediaRepository,
+    playbackManager: PlaybackManager,
     onNavigateBack: () -> Unit,
-    onSongClick: (String) -> Unit = {},
+    onNavigateToNowPlaying: () -> Unit = {},
     onSearchClick: () -> Unit = {}
 ) {
     val viewModel: AllSongsViewModel = viewModel {
-        AllSongsViewModel(mediaRepository = mediaRepository)
+        AllSongsViewModel(
+            mediaRepository = mediaRepository,
+            playbackManager = playbackManager
+        )
     }
     val uiState by viewModel.uiState.collectAsState()
+    val playbackState by playbackManager.playbackState.collectAsState()
 
     Scaffold(
         topBar = {
@@ -84,6 +91,13 @@ fun AllSongsScreen(
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = DeepSpaceBlack
                 )
+            )
+        },
+        bottomBar = {
+            NowPlayingBar(
+                playbackState = playbackState,
+                onPlayPauseClick = { viewModel.onPlayPauseClick() },
+                onBarClick = { onNavigateToNowPlaying() }
             )
         },
         containerColor = DeepSpaceBlack
@@ -169,7 +183,7 @@ fun AllSongsScreen(
                                 SongListItem(
                                     song = song,
                                     trackNumber = index + 1,
-                                    onClick = { onSongClick(song.id) }
+                                    onClick = { viewModel.onSongClick(song) }
                                 )
                             }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/detail/AllSongsViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/detail/AllSongsViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.data.playback.PlaybackManager
 import pe.net.libre.mixtapehaven.data.repository.MediaRepository
 import pe.net.libre.mixtapehaven.ui.home.Song
 
@@ -19,7 +20,8 @@ data class AllSongsUiState(
 )
 
 class AllSongsViewModel(
-    private val mediaRepository: MediaRepository
+    private val mediaRepository: MediaRepository,
+    private val playbackManager: PlaybackManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AllSongsUiState())
@@ -117,5 +119,13 @@ class AllSongsViewModel(
 
     fun clearError() {
         _uiState.value = _uiState.value.copy(errorMessage = null)
+    }
+
+    fun onSongClick(song: Song) {
+        playbackManager.playSong(song)
+    }
+
+    fun onPlayPauseClick() {
+        playbackManager.togglePlayPause()
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/NavGraph.kt
@@ -105,8 +105,12 @@ fun NavGraph(
         composable(Screen.AllSongs.route) {
             AllSongsScreen(
                 mediaRepository = mediaRepository,
+                playbackManager = playbackManager,
                 onNavigateBack = {
                     navController.popBackStack()
+                },
+                onNavigateToNowPlaying = {
+                    navController.navigate(Screen.NowPlaying.route)
                 }
             )
         }


### PR DESCRIPTION
- Added PlaybackManager to AllSongsViewModel for playback control
- Updated AllSongsScreen to handle song clicks and trigger playback
- Added NowPlayingBar to AllSongsScreen for playback status display
- Configured navigation to support Now Playing screen access
- Users can now play songs from the All Songs screen just like the Home screen

This completes playback functionality across all screens that display songs.