### PR TITLE
Add play icon to SongListItem component

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/HomeScreen.kt
@@ -240,7 +240,8 @@ fun HomeScreen(
                             song = song,
                             trackNumber = index + 1,
                             onClick = { viewModel.onSongClick(song) },
-                            isPlaying = playbackState.currentSong?.id == song.id,
+                            isCurrentSong = playbackState.currentSong?.id == song.id,
+                            isPlaying = playbackState.isPlaying,
                             onPlayPauseClick = { viewModel.onPlayPauseClick() }
                         )
                     }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/components/SongListItem.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/components/SongListItem.kt
@@ -37,6 +37,7 @@ fun SongListItem(
     trackNumber: Int,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isCurrentSong: Boolean = false,
     isPlaying: Boolean = false,
     onPlayPauseClick: (() -> Unit)? = null
 ) {
@@ -48,11 +49,11 @@ fun SongListItem(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // Track number (highlight if playing)
+        // Track number (highlight if current song)
         Text(
             text = trackNumber.toString().padStart(2, '0'),
             style = MaterialTheme.typography.bodyLarge,
-            color = if (isPlaying) CyberNeonBlue else CyberNeonBlue.copy(alpha = 0.6f),
+            color = if (isCurrentSong) CyberNeonBlue else CyberNeonBlue.copy(alpha = 0.6f),
             modifier = Modifier.padding(end = 4.dp)
         )
 
@@ -108,8 +109,8 @@ fun SongListItem(
             color = GunmetalGray
         )
 
-        // Play/Pause button (only show if callback is provided)
-        if (onPlayPauseClick != null) {
+        // Play/Pause button (only show for current song)
+        if (onPlayPauseClick != null && isCurrentSong) {
             IconButton(
                 onClick = onPlayPauseClick,
                 modifier = Modifier.size(40.dp)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/detail/AllSongsScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/home/detail/AllSongsScreen.kt
@@ -179,7 +179,8 @@ fun AllSongsScreen(
                                     song = song,
                                     trackNumber = index + 1,
                                     onClick = { viewModel.onSongClick(song) },
-                                    isPlaying = playbackState.currentSong?.id == song.id,
+                                    isCurrentSong = playbackState.currentSong?.id == song.id,
+                                    isPlaying = playbackState.isPlaying,
                                     onPlayPauseClick = { viewModel.onPlayPauseClick() }
                                 )
                             }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/playlist/PlaylistDetailScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/playlist/PlaylistDetailScreen.kt
@@ -291,7 +291,8 @@ fun PlaylistDetailScreen(
                             trackNumber = index + 1,
                             song = song,
                             onClick = { viewModel.onSongClick(song) },
-                            isPlaying = playbackState.currentSong?.id == song.id,
+                            isCurrentSong = playbackState.currentSong?.id == song.id,
+                            isPlaying = playbackState.isPlaying,
                             onPlayPauseClick = { viewModel.onPlayPauseClick() }
                         )
                     }


### PR DESCRIPTION
Previously, the play/pause icon was displayed for all songs in the list. This change ensures the icon only appears for the currently selected song, showing a pause icon when playing and a play icon when paused.

Changes:
- Added isCurrentSong parameter to SongListItem to track current song
- Updated play/pause button visibility condition to check isCurrentSong
- Modified all SongListItem callers to pass both isCurrentSong and isPlaying states
- isPlaying now correctly reflects actual playback state from PlaybackState

Files modified:
- SongListItem.kt: Component signature and logic
- AllSongsScreen.kt: Updated SongListItem caller
- HomeScreen.kt: Updated SongListItem caller
- PlaylistDetailScreen.kt: Updated SongListItem caller