### PR TITLE
chore: bump compileSdk to 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,9 +17,7 @@ tasks.named("check") {
 android {
     namespace = "pe.net.libre.mixtapehaven"
     compileSdk {
-        version = release(36) {
-            minorApiLevel = 1
-        }
+        version = release(37)
     }
 
     defaultConfig {


### PR DESCRIPTION
Bumps `compileSdk` from 36.1 to 37 so the androidx group update (#125 — `androidx.core:1.19.0`, `androidx.lifecycle:lifecycle-viewmodel-compose:2.11.0`, etc.) passes its AAR metadata check, which requires consumers to compile against API 37.

`targetSdk` and `minSdk` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)