### PR TITLE
refactor(playback): add stream-resolver and queue-refill seams (#130)

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -32,8 +32,21 @@ class PlayerController(
     private val appContext = context.applicationContext
     private val scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
 
+    /**
+     * Resolves the playable URL for a [Track]. Defaults to the remote static stream from
+     * [repository]; swap it to source local files (e.g. downloads) without touching [play].
+     */
+    var streamUrlResolver: (Track) -> String? = { it.id?.let(repository::audioStreamUrl) }
+
+    /**
+     * Invoked when playback nears the end of the queue (fewer than [REFILL_THRESHOLD] items
+     * remain). The returned tracks are appended to the queue. Null disables refilling.
+     */
+    var onQueueRunningLow: (suspend () -> List<Track>)? = null
+
     private var controller: MediaController? = null
     private var pendingAction: (() -> Unit)? = null
+    private var refilling = false
     private val tracksById = mutableMapOf<String, Track>()
 
     private val _nowPlaying = MutableStateFlow<Track?>(null)
@@ -55,6 +68,7 @@ class PlayerController(
 
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
             updateNowPlaying(mediaItem)
+            maybeRefillQueue()
         }
 
         override fun onPositionDiscontinuity(
@@ -85,12 +99,7 @@ class PlayerController(
     fun play(queue: List<Track>, startIndex: Int = 0) {
         val action = action@{
             val c = controller ?: return@action
-            val items = queue.mapNotNull { track ->
-                val id = track.id ?: return@mapNotNull null
-                val url = repository.audioStreamUrl(id) ?: return@mapNotNull null
-                tracksById[id] = track
-                buildMediaItem(track, id, url)
-            }
+            val items = buildItems(queue)
             if (items.isEmpty()) return@action
             c.setMediaItems(items, startIndex.coerceIn(0, items.lastIndex), 0L)
             c.prepare()
@@ -136,6 +145,34 @@ class PlayerController(
     /** The controller only if it is still connected to a live service, else null. */
     private fun activeController(): MediaController? = controller?.takeIf { it.isConnected }
 
+    /**
+     * Resolve [tracks] into media items, registering each in [tracksById] so [nowPlaying] can be
+     * recovered for items appended later via the refill hook. Tracks without an id or a resolvable
+     * URL are skipped.
+     */
+    private fun buildItems(tracks: List<Track>): List<MediaItem> =
+        resolvePlayables(tracks, streamUrlResolver).map { (track, id, url) ->
+            tracksById[id] = track
+            buildMediaItem(track, id, url)
+        }
+
+    /** Ask [onQueueRunningLow] for more tracks and append them when the queue is running low. */
+    private fun maybeRefillQueue() {
+        val refill = onQueueRunningLow
+        val c = activeController()
+        if (refill == null || c == null || refilling) return
+        if (!shouldRefillQueue(c.currentMediaItemIndex, c.mediaItemCount, REFILL_THRESHOLD)) return
+        refilling = true
+        scope.launch {
+            try {
+                val items = buildItems(refill())
+                if (items.isNotEmpty()) activeController()?.addMediaItems(items)
+            } finally {
+                refilling = false
+            }
+        }
+    }
+
     private fun connect() {
         val token = SessionToken(appContext, ComponentName(appContext, PlaybackService::class.java))
         val future = MediaController.Builder(appContext, token).buildAsync()
@@ -179,5 +216,30 @@ class PlayerController(
 
     private companion object {
         const val PROGRESS_INTERVAL_MS = 500L
+        const val REFILL_THRESHOLD = 3
     }
 }
+
+/** A [Track] paired with the stream URL used to build its media item. */
+internal data class PlayableTrack(val track: Track, val id: String, val url: String)
+
+/**
+ * Pair each resolvable [Track] with its stream URL via [resolver]. Tracks without an id or whose
+ * URL cannot be resolved are dropped. Pure (no media3/Android deps) so the resolver seam used by
+ * [PlayerController.play] and the queue-refill hook is unit-coverable.
+ */
+internal fun resolvePlayables(
+    tracks: List<Track>,
+    resolver: (Track) -> String?,
+): List<PlayableTrack> = tracks.mapNotNull { track ->
+    val id = track.id ?: return@mapNotNull null
+    val url = resolver(track) ?: return@mapNotNull null
+    PlayableTrack(track, id, url)
+}
+
+/**
+ * True when fewer than [threshold] items remain after [currentIndex] in a queue of [itemCount],
+ * signalling that the refill hook should be invoked.
+ */
+internal fun shouldRefillQueue(currentIndex: Int, itemCount: Int, threshold: Int): Boolean =
+    itemCount - currentIndex - 1 < threshold

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -3,14 +3,17 @@ package pe.net.libre.mixtapehaven.data.playback
 import android.content.ComponentName
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -47,6 +50,7 @@ class PlayerController(
     private var controller: MediaController? = null
     private var pendingAction: (() -> Unit)? = null
     private var refilling = false
+    private var refillJob: Job? = null
     private val tracksById = mutableMapOf<String, Track>()
 
     private val _nowPlaying = MutableStateFlow<Track?>(null)
@@ -99,6 +103,9 @@ class PlayerController(
     fun play(queue: List<Track>, startIndex: Int = 0) {
         val action = action@{
             val c = controller ?: return@action
+            // Drop any in-flight refill so its tracks aren't appended to this new queue.
+            refillJob?.cancel()
+            refilling = false
             val items = buildItems(queue)
             if (items.isEmpty()) return@action
             c.setMediaItems(items, startIndex.coerceIn(0, items.lastIndex), 0L)
@@ -163,9 +170,16 @@ class PlayerController(
         if (refill == null || c == null || refilling) return
         if (!shouldRefillQueue(c.currentMediaItemIndex, c.mediaItemCount, REFILL_THRESHOLD)) return
         refilling = true
-        scope.launch {
+        refillJob = scope.launch {
             try {
-                val items = buildItems(refill())
+                // The refill hook may do network/IO; a failure must not crash playback, but
+                // cancellation (e.g. a new play()) must still propagate to end the coroutine.
+                val items = runCatching { buildItems(refill()) }
+                    .onFailure {
+                        if (it is CancellationException) throw it
+                        Log.w(TAG, "Queue refill failed", it)
+                    }
+                    .getOrDefault(emptyList())
                 if (items.isNotEmpty()) activeController()?.addMediaItems(items)
             } finally {
                 refilling = false
@@ -215,6 +229,7 @@ class PlayerController(
     }
 
     private companion object {
+        const val TAG = "PlayerController"
         const val PROGRESS_INTERVAL_MS = 500L
         const val REFILL_THRESHOLD = 3
     }
@@ -239,7 +254,10 @@ internal fun resolvePlayables(
 
 /**
  * True when fewer than [threshold] items remain after [currentIndex] in a queue of [itemCount],
- * signalling that the refill hook should be invoked.
+ * signalling that the refill hook should be invoked. An empty queue ([itemCount] == 0) never
+ * refills: a stopped/cleared player reports an empty queue and must stay stopped.
  */
-internal fun shouldRefillQueue(currentIndex: Int, itemCount: Int, threshold: Int): Boolean =
-    itemCount - currentIndex - 1 < threshold
+internal fun shouldRefillQueue(currentIndex: Int, itemCount: Int, threshold: Int): Boolean {
+    if (itemCount == 0) return false
+    return itemCount - currentIndex - 1 < threshold
+}

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/PlayerControllerSeamsTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/PlayerControllerSeamsTest.kt
@@ -53,4 +53,10 @@ class PlayerControllerSeamsTest {
         assertTrue(shouldRefillQueue(currentIndex = 2, itemCount = 5, threshold = 3))
         assertTrue(shouldRefillQueue(currentIndex = 4, itemCount = 5, threshold = 3))
     }
+
+    @Test
+    fun `shouldRefillQueue never refills an empty queue`() {
+        // A stopped/cleared player reports itemCount 0; it must stay stopped, not refill.
+        assertFalse(shouldRefillQueue(currentIndex = 0, itemCount = 0, threshold = 3))
+    }
 }

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/PlayerControllerSeamsTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/PlayerControllerSeamsTest.kt
@@ -1,0 +1,56 @@
+package pe.net.libre.mixtapehaven.data.playback
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import pe.net.libre.mixtapehaven.model.Track
+
+/** Unit coverage for the stream-resolver and queue-refill seams introduced for #128/#129. */
+class PlayerControllerSeamsTest {
+
+    private fun track(id: String?, title: String = "t") =
+        Track(title = title, artist = "a", durationLabel = "0:00", artColor = Color(0xFF000000), id = id)
+
+    @Test
+    fun `resolvePlayables uses the provided resolver`() {
+        val tracks = listOf(track("1"), track("2"))
+
+        val playables = resolvePlayables(tracks) { "stream://${it.id}" }
+
+        assertEquals(
+            listOf("stream://1", "stream://2"),
+            playables.map { it.url },
+        )
+        assertEquals(listOf("1", "2"), playables.map { it.id })
+    }
+
+    @Test
+    fun `resolvePlayables drops tracks without an id`() {
+        val tracks = listOf(track(null), track("2"))
+
+        val playables = resolvePlayables(tracks) { "stream://${it.id}" }
+
+        assertEquals(listOf("2"), playables.map { it.id })
+    }
+
+    @Test
+    fun `resolvePlayables drops tracks the resolver cannot resolve`() {
+        val tracks = listOf(track("1"), track("2"))
+
+        // Resolver swap: e.g. only locally-downloaded tracks resolve to a file URL.
+        val playables = resolvePlayables(tracks) { if (it.id == "2") "file://2" else null }
+
+        assertEquals(listOf("2"), playables.map { it.id })
+        assertEquals(listOf("file://2"), playables.map { it.url })
+    }
+
+    @Test
+    fun `shouldRefillQueue triggers only when remaining items fall below threshold`() {
+        // Queue of 5, threshold 3: refill once 3 or fewer items remain after current.
+        assertFalse(shouldRefillQueue(currentIndex = 0, itemCount = 5, threshold = 3))
+        assertTrue(shouldRefillQueue(currentIndex = 2, itemCount = 5, threshold = 3))
+        assertTrue(shouldRefillQueue(currentIndex = 4, itemCount = 5, threshold = 3))
+    }
+}


### PR DESCRIPTION
Closes #130.

Small prep refactor so #128 (Random Walk) and #129 (Auto-download) can be built in parallel without colliding in `PlayerController.play()`.

## Changes (`data/playback/PlayerController.kt`)

1. **Stream-URL resolver indirection** — `play()` no longer calls `repository.audioStreamUrl(id)` directly. It goes through an injectable property:
   ```kotlin
   var streamUrlResolver: (Track) -> String? = { it.id?.let(repository::audioStreamUrl) }
   ```
   Default keeps today's remote static-stream behavior. #129 swaps in "local file if downloaded, else stream" without touching `play()`.

2. **Queue-refill hook** — invoked from `onMediaItemTransition` when fewer than `REFILL_THRESHOLD` (3) items remain:
   ```kotlin
   var onQueueRunningLow: (suspend () -> List<Track>)? = null
   ```
   The controller appends the returned tracks via `addMediaItems`. Default `null` = no refill (current behavior). A `refilling` guard prevents re-entrant appends. #128 plugs its random-append logic in here.

3. **`tracksById` population** — `play()` and the refill path share a `buildItems()` helper that registers every resolved track in `tracksById`, so `nowPlaying` resolves correctly for items appended via the refill hook.

## Testability

Extracted two pure, Android-free helpers so both seams are unit-coverable:
- `resolvePlayables(tracks, resolver)` — resolver seam
- `shouldRefillQueue(currentIndex, itemCount, threshold)` — refill trigger

Added `PlayerControllerSeamsTest` covering resolver swap (custom URLs, dropping idless/unresolvable tracks) and the refill threshold.

## Verification

- No behavior change with defaults — existing playback path unchanged.
- `./gradlew testDebugUnitTest detekt assembleDebug` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
