### PR TITLE
feat: Random Walk continuous shuffle playlist (#128)

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
@@ -101,6 +101,21 @@ class JellyfinRepository(
         return result.items.orEmpty().map { it.toTrack(client) }
     }
 
+    /** A randomly ordered batch of tracks from the whole library, for the endless Random Walk queue. */
+    suspend fun randomTracks(limit: Int = 50): List<Track> {
+        val client = requireApi()
+        val result by client.itemsApi.getItems(
+            GetItemsRequest(
+                userId = userId,
+                includeItemTypes = listOf(BaseItemKind.AUDIO),
+                recursive = true,
+                sortBy = listOf(ItemSortBy.RANDOM),
+                limit = limit,
+            ),
+        )
+        return result.items.orEmpty().map { it.toTrack(client) }
+    }
+
     suspend fun albumTracks(albumId: String): List<Track> {
         val client = requireApi()
         val parent = runCatching { UUID.fromString(albumId) }.getOrNull() ?: return emptyList()

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -47,6 +47,11 @@ class PlayerController(
      */
     var onQueueRunningLow: (suspend () -> List<Track>)? = null
 
+    private val _source = MutableStateFlow(PlaybackSource.LIBRARY)
+
+    /** The origin of the current queue, surfaced as the "PLAYING FROM" label on Now Playing. */
+    val source: StateFlow<PlaybackSource> = _source.asStateFlow()
+
     private var controller: MediaController? = null
     private var pendingAction: (() -> Unit)? = null
     private var refilling = false
@@ -97,6 +102,11 @@ class PlayerController(
                 delay(PROGRESS_INTERVAL_MS)
             }
         }
+    }
+
+    /** Set the origin label for the next queue; call before [play] when starting a new source. */
+    fun setSource(source: PlaybackSource) {
+        _source.value = source
     }
 
     /** Replace the queue with [queue] and start playback at [startIndex]. */
@@ -233,6 +243,12 @@ class PlayerController(
         const val PROGRESS_INTERVAL_MS = 500L
         const val REFILL_THRESHOLD = 3
     }
+}
+
+/** Where the current queue came from; [label] is shown as the "PLAYING FROM" value. */
+enum class PlaybackSource(val label: String) {
+    LIBRARY("Your library"),
+    RANDOM_WALK("Random Walk"),
 }
 
 /** A [Track] paired with the stream URL used to build its media item. */

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -107,6 +107,10 @@ class PlayerController(
     /** Set the origin label for the next queue; call before [play] when starting a new source. */
     fun setSource(source: PlaybackSource) {
         _source.value = source
+        // Leaving Random Walk: stop the endless refill so its tracks aren't appended to other queues.
+        if (source != PlaybackSource.RANDOM_WALK) {
+            onQueueRunningLow = null
+        }
     }
 
     /** Replace the queue with [queue] and start playback at [startIndex]. */

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/RandomWalk.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/RandomWalk.kt
@@ -31,7 +31,11 @@ class RandomWalk(
      */
     private suspend fun nextBatch(): List<Track> {
         val fetched = repository.randomTracks(batchSize + recentIds.size)
-        val fresh = filterRecent(fetched, recentIds.toSet()).take(batchSize)
+        val recent = recentIds.toSet()
+        // Small library: the recent window can cover everything, so the dedupe falls back to the raw
+        // batch. Reset the stale history in that case rather than letting it stall the queue.
+        if (fetched.isNotEmpty() && filterRecent(fetched, recent).isEmpty()) recentIds.clear()
+        val fresh = selectFreshBatch(fetched, recent, batchSize)
         rememberPlayed(fresh)
         return fresh
     }
@@ -46,7 +50,9 @@ class RandomWalk(
 
     private companion object {
         const val DEFAULT_BATCH_SIZE = 50
-        const val RECENT_WINDOW = 50
+        // A multiple of the batch size so a fresh batch never evicts the whole previous one, keeping
+        // just-played tracks out of the next refill.
+        const val RECENT_WINDOW = 150
     }
 }
 
@@ -57,3 +63,14 @@ class RandomWalk(
  */
 internal fun filterRecent(tracks: List<Track>, recentIds: Set<String>): List<Track> =
     tracks.filter { it.id !in recentIds }
+
+/**
+ * Pick up to [batchSize] tracks from [fetched] that aren't in [recentIds]. If every fetched track is
+ * in the recent window (a small library whose history covers it all), fall back to the raw [fetched]
+ * batch so the endless queue never stalls. Pure for unit coverage.
+ */
+internal fun selectFreshBatch(
+    fetched: List<Track>,
+    recentIds: Set<String>,
+    batchSize: Int,
+): List<Track> = filterRecent(fetched, recentIds).ifEmpty { fetched }.take(batchSize)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/RandomWalk.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/RandomWalk.kt
@@ -1,0 +1,59 @@
+package pe.net.libre.mixtapehaven.data.playback
+
+import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
+import pe.net.libre.mixtapehaven.model.Track
+
+/**
+ * Drives Random Walk: a one-tap, never-ending shuffled queue across the whole library. Seeds the
+ * queue with a random batch, then refills it forever via [PlayerController.onQueueRunningLow],
+ * skipping tracks played in the recent window so the same song never repeats back-to-back.
+ */
+class RandomWalk(
+    private val repository: JellyfinRepository,
+    private val playerController: PlayerController,
+    private val batchSize: Int = DEFAULT_BATCH_SIZE,
+) {
+    // Ids handed out recently, oldest first; capped at RECENT_WINDOW to avoid starving small libraries.
+    private val recentIds = ArrayDeque<String>()
+
+    /** Seed the queue and arm the refill hook. No-op if the library has no tracks. */
+    suspend fun start() {
+        val initial = nextBatch()
+        if (initial.isEmpty()) return
+        playerController.setSource(PlaybackSource.RANDOM_WALK)
+        playerController.play(initial, startIndex = 0)
+        playerController.onQueueRunningLow = { nextBatch() }
+    }
+
+    /**
+     * Fetch a fresh random batch, drop ids in the recent window, and remember what we hand out.
+     * Over-fetches by the recent-window size so a full window of collisions still yields [batchSize].
+     */
+    private suspend fun nextBatch(): List<Track> {
+        val fetched = repository.randomTracks(batchSize + recentIds.size)
+        val fresh = filterRecent(fetched, recentIds.toSet()).take(batchSize)
+        rememberPlayed(fresh)
+        return fresh
+    }
+
+    private fun rememberPlayed(tracks: List<Track>) {
+        tracks.forEach { track ->
+            val id = track.id ?: return@forEach
+            recentIds.addLast(id)
+            while (recentIds.size > RECENT_WINDOW) recentIds.removeFirst()
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_BATCH_SIZE = 50
+        const val RECENT_WINDOW = 50
+    }
+}
+
+/**
+ * Drop tracks whose id is in [recentIds] so refilled batches never replay the recent window. Tracks
+ * without an id pass through (they are dropped later when no stream URL can be resolved). Pure so the
+ * Random Walk dedupe is unit-coverable.
+ */
+internal fun filterRecent(tracks: List<Track>, recentIds: Set<String>): List<Track> =
+    tracks.filter { it.id !in recentIds }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -103,7 +103,12 @@ fun HomeScreen(
             }
         }
 
-        RandomWalkCard(onPlay = onOpenNowPlaying)
+        RandomWalkCard(
+            onPlay = {
+                viewModel.startRandomWalk()
+                onOpenNowPlaying()
+            },
+        )
 
         SearchField(
             placeholder = "Search songs, albums, artists",

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
+import pe.net.libre.mixtapehaven.data.playback.PlaybackSource
 import pe.net.libre.mixtapehaven.data.playback.PlayerController
+import pe.net.libre.mixtapehaven.data.playback.RandomWalk
 import pe.net.libre.mixtapehaven.model.Album
 
 class HomeViewModel(
@@ -57,7 +59,17 @@ class HomeViewModel(
         val albumId = album.id ?: return
         viewModelScope.launch {
             val tracks = runCatching { repository.albumTracks(albumId) }.getOrDefault(emptyList())
-            if (tracks.isNotEmpty()) playerController.play(tracks, startIndex = 0)
+            if (tracks.isNotEmpty()) {
+                playerController.setSource(PlaybackSource.LIBRARY)
+                playerController.play(tracks, startIndex = 0)
+            }
+        }
+    }
+
+    /** Start an endless shuffled queue across the whole library. */
+    fun startRandomWalk() {
+        viewModelScope.launch {
+            runCatching { RandomWalk(repository, playerController).start() }
         }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingScreen.kt
@@ -54,6 +54,7 @@ fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
     val isPlaying by viewModel.isPlaying.collectAsState()
     val positionMs by viewModel.positionMs.collectAsState()
     val durationMs by viewModel.durationMs.collectAsState()
+    val source by viewModel.source.collectAsState()
 
     val progress = if (durationMs > 0) (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
 
@@ -87,7 +88,7 @@ fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                     textAlign = TextAlign.Center,
                 )
                 Text(
-                    "Your library",
+                    source.label,
                     style = MaterialTheme.typography.labelMedium,
                     color = Accent,
                     textAlign = TextAlign.Center,

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingViewModel.kt
@@ -1,6 +1,7 @@
 package pe.net.libre.mixtapehaven.ui.screens.nowplaying
 
 import androidx.lifecycle.ViewModel
+import pe.net.libre.mixtapehaven.data.playback.PlaybackSource
 import pe.net.libre.mixtapehaven.data.playback.PlayerController
 import pe.net.libre.mixtapehaven.model.Track
 import kotlinx.coroutines.flow.StateFlow
@@ -13,6 +14,7 @@ class NowPlayingViewModel(
     val isPlaying: StateFlow<Boolean> = playerController.isPlaying
     val positionMs: StateFlow<Long> = playerController.positionMs
     val durationMs: StateFlow<Long> = playerController.durationMs
+    val source: StateFlow<PlaybackSource> = playerController.source
 
     fun playPause() = playerController.playPause()
     fun next() = playerController.next()

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/RandomWalkTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/RandomWalkTest.kt
@@ -1,0 +1,41 @@
+package pe.net.libre.mixtapehaven.data.playback
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import pe.net.libre.mixtapehaven.model.Track
+
+/** Unit coverage for the Random Walk dedupe filter (#128). */
+class RandomWalkTest {
+
+    private fun track(id: String?) =
+        Track(title = "t", artist = "a", durationLabel = "0:00", artColor = Color(0xFF000000), id = id)
+
+    @Test
+    fun `filterRecent drops ids in the recent window`() {
+        val tracks = listOf(track("1"), track("2"), track("3"))
+
+        val fresh = filterRecent(tracks, recentIds = setOf("1", "3"))
+
+        assertEquals(listOf("2"), fresh.map { it.id })
+    }
+
+    @Test
+    fun `filterRecent keeps everything when the recent window is empty`() {
+        val tracks = listOf(track("1"), track("2"))
+
+        val fresh = filterRecent(tracks, recentIds = emptySet())
+
+        assertEquals(listOf("1", "2"), fresh.map { it.id })
+    }
+
+    @Test
+    fun `filterRecent keeps tracks without an id`() {
+        // Null-id tracks can't be deduped; they pass through and are dropped later when unresolvable.
+        val tracks = listOf(track(null), track("1"))
+
+        val fresh = filterRecent(tracks, recentIds = setOf("1"))
+
+        assertEquals(listOf(null), fresh.map { it.id })
+    }
+}

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/RandomWalkTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/RandomWalkTest.kt
@@ -38,4 +38,30 @@ class RandomWalkTest {
 
         assertEquals(listOf(null), fresh.map { it.id })
     }
+
+    @Test
+    fun `selectFreshBatch returns unseen tracks capped at the batch size`() {
+        val fetched = listOf(track("1"), track("2"), track("3"))
+
+        val fresh = selectFreshBatch(fetched, recentIds = setOf("1"), batchSize = 1)
+
+        assertEquals(listOf("2"), fresh.map { it.id })
+    }
+
+    @Test
+    fun `selectFreshBatch falls back to the fetched batch when the window covers everything`() {
+        // Small library: every fetched id is in the recent window, so dedupe alone would stall.
+        val fetched = listOf(track("1"), track("2"))
+
+        val fresh = selectFreshBatch(fetched, recentIds = setOf("1", "2"), batchSize = 50)
+
+        assertEquals(listOf("1", "2"), fresh.map { it.id })
+    }
+
+    @Test
+    fun `selectFreshBatch returns empty when nothing was fetched`() {
+        val fresh = selectFreshBatch(emptyList(), recentIds = setOf("1"), batchSize = 50)
+
+        assertEquals(emptyList<String>(), fresh.map { it.id })
+    }
 }


### PR DESCRIPTION
Closes #128.

Implements **Random Walk** — a one-tap, never-ending shuffled queue across the entire Jellyfin music library. Built on the PlayerController seams from #130/#131 (does not touch `play()`).

## Changes
- **`JellyfinRepository.randomTracks(limit)`** — `getItems(includeItemTypes=[AUDIO], recursive=true, sortBy=[RANDOM])`, mapped via the existing `toTrack`.
- **`RandomWalk`** orchestrator — seeds the queue with an initial random batch, calls `play(...)`, and wires `onQueueRunningLow = { nextBatch() }` so the controller refills the queue forever via its built-in lookahead threshold.
- **Immediate-repeat avoidance** — keeps a deque of the last ~50 handed-out track ids and filters them out of refilled batches (over-fetching to absorb collisions) via a pure, unit-tested `filterRecent` helper.
- **`PlaybackSource` enum** in `PlayerController` exposed as a `StateFlow`, driving the Now Playing "PLAYING FROM" label ("Random Walk" vs "Your library"); album playback resets it to `LIBRARY`.
- **Home `RandomWalkCard`** now starts the walk then navigates to Now Playing, mirroring the album-click flow.

## Tests
- 3 unit tests covering the dedupe filter.
- `assembleDebug`, `detekt`, `test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)