### PR TITLE
feat: Auto-download while playing + offline playback (#129)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.detekt)
 }
 
@@ -62,6 +63,9 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
     implementation(libs.jellyfin.core)
     implementation(libs.slf4j.api)
     implementation(libs.okhttp)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDao.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDao.kt
@@ -1,0 +1,34 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+/** Room access to the offline download library. */
+@Dao
+interface DownloadDao {
+
+    /** All saved/in-progress downloads, oldest first, observed for the UI. */
+    @Query("SELECT * FROM downloaded_tracks ORDER BY rowid")
+    fun observeAll(): Flow<List<DownloadedTrack>>
+
+    /** Running total of bytes used by saved downloads. */
+    @Query("SELECT COALESCE(SUM(sizeBytes), 0) FROM downloaded_tracks")
+    fun observeTotalSize(): Flow<Long>
+
+    @Upsert
+    suspend fun upsert(track: DownloadedTrack)
+
+    @Query("SELECT * FROM downloaded_tracks WHERE id = :id")
+    suspend fun findById(id: String): DownloadedTrack?
+
+    @Query("SELECT * FROM downloaded_tracks")
+    suspend fun getAll(): List<DownloadedTrack>
+
+    @Query("DELETE FROM downloaded_tracks WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    @Query("DELETE FROM downloaded_tracks")
+    suspend fun clear()
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDatabase.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDatabase.kt
@@ -1,0 +1,23 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+/** Room database holding the offline download library. */
+@Database(entities = [DownloadedTrack::class], version = 1, exportSchema = false)
+abstract class DownloadDatabase : RoomDatabase() {
+
+    abstract fun downloadDao(): DownloadDao
+
+    companion object {
+        /** Build the app's download database in the default location. */
+        fun build(context: Context): DownloadDatabase =
+            Room.databaseBuilder(
+                context.applicationContext,
+                DownloadDatabase::class.java,
+                "downloads.db",
+            ).build()
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadManager.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadManager.kt
@@ -1,0 +1,233 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.compose.ui.graphics.toArgb
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.ResponseBody
+import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
+import pe.net.libre.mixtapehaven.data.playback.PlayerController
+import pe.net.libre.mixtapehaven.model.Track
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.Collections
+
+/** Progress of the download currently in flight: the [track] being saved and its [percent] (0-100). */
+data class DownloadProgress(val track: Track, val percent: Int)
+
+/**
+ * App-scoped service that saves the original file bytes of tracks as they play, so the library
+ * becomes available offline. Observes [PlayerController.nowPlaying]; when auto-download is enabled
+ * it streams the static original file from [repository] to internal storage and records a
+ * [DownloadedTrack] row. Failures never crash playback and already-saved tracks are skipped.
+ */
+class DownloadManager(
+    context: Context,
+    private val repository: JellyfinRepository,
+    private val dao: DownloadDao,
+    private val settingsStore: DownloadSettingsStore,
+    private val playerController: PlayerController,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    private val client: OkHttpClient = OkHttpClient(),
+) {
+    private val appContext = context.applicationContext
+    private val downloadsDir: File = File(appContext.filesDir, DOWNLOADS_DIR).apply { mkdirs() }
+
+    /** Saved + in-progress downloads, observed by the Downloads/Home UI. */
+    val downloads: Flow<List<DownloadedTrack>> = dao.observeAll()
+
+    /** Running total of bytes used by saved downloads. */
+    val totalSizeBytes: Flow<Long> = dao.observeTotalSize()
+
+    private val _progress = MutableStateFlow<DownloadProgress?>(null)
+    val progress: StateFlow<DownloadProgress?> = _progress.asStateFlow()
+
+    @Volatile
+    private var autoDownloadEnabled: Boolean = true
+
+    /** Completed downloads as id -> file path, kept in memory so the resolver lookup is synchronous. */
+    @Volatile
+    private var completedPaths: Map<String, String> = emptyMap()
+
+    private val inProgress: MutableSet<String> = Collections.synchronizedSet(mutableSetOf())
+
+    /** Begin observing settings, the saved library, and playback. Idempotent per instance. */
+    fun start() {
+        scope.launch { settingsStore.autoDownloadEnabled.collect { autoDownloadEnabled = it } }
+        scope.launch {
+            dao.observeAll().collect { rows ->
+                completedPaths = rows.filter { it.complete }.associate { it.id to it.filePath }
+            }
+        }
+        scope.launch {
+            playerController.nowPlaying.collect { track -> track?.let(::onTrackPlaying) }
+        }
+    }
+
+    /**
+     * Local playback URI for [track] if its bytes are saved, else null. Synchronous (in-memory
+     * lookup) so it can back [PlayerController.streamUrlResolver] when media items are built.
+     */
+    fun localUriFor(track: Track): String? {
+        val path = track.id?.let { completedPaths[it] } ?: return null
+        val file = File(path)
+        return if (file.exists()) Uri.fromFile(file).toString() else null
+    }
+
+    /** Usable bytes remaining on the volume backing the download directory. */
+    fun usableSpaceBytes(): Long = downloadsDir.usableSpace
+
+    /** Delete every saved file and clear the download library. */
+    suspend fun removeAll() {
+        val rows = dao.getAll()
+        dao.clear()
+        withContext(Dispatchers.IO) {
+            rows.forEach { runCatching { File(it.filePath).delete() } }
+        }
+        completedPaths = emptyMap()
+        _progress.value = null
+    }
+
+    private fun onTrackPlaying(track: Track) {
+        val id = track.id
+        if (!autoDownloadEnabled || id == null) return
+        if (completedPaths.containsKey(id) || !inProgress.add(id)) return
+        scope.launch {
+            try {
+                runCatching { download(track, id) }
+                    .onFailure { Log.w(TAG, "Download failed for $id", it) }
+            } finally {
+                inProgress.remove(id)
+                if (_progress.value?.track?.id == id) _progress.value = null
+            }
+        }
+    }
+
+    private suspend fun download(track: Track, id: String) {
+        val url = downloadUrlOrNull(id) ?: return
+        val target = File(downloadsDir, id)
+        val part = File(downloadsDir, "$id.part")
+        val saved = runCatching { streamToFile(url, part, track) }
+            .onFailure { part.delete() }
+            .getOrThrow()
+        if (saved && part.renameTo(target)) {
+            dao.upsert(track.toDownloadedTrack(id, target.path, target.length()))
+        } else {
+            part.delete()
+        }
+    }
+
+    /** The stream URL to download for [id], or null if it is already saved or storage is low. */
+    private suspend fun downloadUrlOrNull(id: String): String? {
+        val alreadySaved = dao.findById(id)?.complete == true
+        val lowStorage = !shouldStartDownload(usableSpaceBytes(), MIN_FREE_BYTES)
+        if (lowStorage) Log.w(TAG, "Skipping download of $id: storage low")
+        return if (alreadySaved || lowStorage) null else repository.audioStreamUrl(id)
+    }
+
+    /** Stream [url] into [part], emitting progress for [track]. Returns false if cancelled mid-stream. */
+    private suspend fun streamToFile(url: String, part: File, track: Track): Boolean {
+        val request = Request.Builder().url(url).build()
+        return client.newCall(request).execute().use { response ->
+            val body = response.body
+            if (!response.isSuccessful || body == null) false else copyToFile(body, part, track)
+        }
+    }
+
+    /** Copy [body] to [part], emitting progress for [track]. Returns false if cancelled mid-stream. */
+    private suspend fun copyToFile(body: ResponseBody, part: File, track: Track): Boolean {
+        val total = body.contentLength()
+        return part.outputStream().use { output ->
+            body.byteStream().use { input -> pumpStream(input, output, total, track) }
+        }
+    }
+
+    /** Pump [input] to [output] in chunks, emitting progress. False if cancelled before completion. */
+    private suspend fun pumpStream(
+        input: InputStream,
+        output: OutputStream,
+        total: Long,
+        track: Track,
+    ): Boolean {
+        val buffer = ByteArray(BUFFER_BYTES)
+        var downloaded = 0L
+        var lastPercent = -1
+        while (currentCoroutineContext().isActive) {
+            val read = input.read(buffer)
+            if (read < 0) return true
+            output.write(buffer, 0, read)
+            downloaded += read
+            lastPercent = emitProgress(track, downloaded, total, lastPercent)
+        }
+        return false
+    }
+
+    /** Emit a [DownloadProgress] update for [track] when the percent changes; returns the new percent. */
+    private fun emitProgress(track: Track, downloaded: Long, total: Long, lastPercent: Int): Int {
+        val percent = percentOf(downloaded, total)
+        if (percent != lastPercent) _progress.value = DownloadProgress(track, percent)
+        return percent
+    }
+
+    private fun Track.toDownloadedTrack(id: String, path: String, size: Long) = DownloadedTrack(
+        id = id,
+        title = title,
+        artist = artist,
+        durationLabel = durationLabel,
+        imageUrl = imageUrl,
+        artColorArgb = artColor.toArgb(),
+        filePath = path,
+        sizeBytes = size,
+        complete = true,
+    )
+
+    private companion object {
+        const val TAG = "DownloadManager"
+        const val DOWNLOADS_DIR = "downloads"
+        const val BUFFER_BYTES = 64 * 1024
+        const val MIN_FREE_BYTES = 200L * 1024 * 1024
+    }
+}
+
+/**
+ * Local-first URL resolution: the saved local URI from [localUri] when present, else the remote
+ * stream from [streamUrl]. Pure (no Android/file deps) so the resolver seam is unit-coverable.
+ */
+internal fun resolveLocalFirst(
+    track: Track,
+    localUri: (Track) -> String?,
+    streamUrl: (String) -> String?,
+): String? = localUri(track) ?: track.id?.let(streamUrl)
+
+/** True when enough free space remains to start a download (keeps at least [minFreeBytes] free). */
+internal fun shouldStartDownload(freeBytes: Long, minFreeBytes: Long): Boolean =
+    freeBytes > minFreeBytes
+
+/** Download percent (0-100) given bytes [downloaded] of [total]; 0 when total is unknown. */
+internal fun percentOf(downloaded: Long, total: Long): Int =
+    if (total <= 0) 0 else ((downloaded * 100) / total).toInt().coerceIn(0, 100)
+
+/** Human-readable byte size, e.g. "9.8 MB" or "1.2 GB". */
+internal fun formatBytes(bytes: Long): String {
+    if (bytes <= 0) return "0 MB"
+    val mb = bytes / 1_000_000.0
+    return when {
+        mb >= 1000 -> "%.1f GB".format(mb / 1000)
+        mb >= 10 -> "%.0f MB".format(mb)
+        else -> "%.1f MB".format(mb)
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadManager.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadManager.kt
@@ -134,13 +134,18 @@ class DownloadManager(
         val target = File(downloadsDir, id)
         val part = File(downloadsDir, "$id.part")
         val saved = runCatching { streamToFile(url, part, track) }
-            .onFailure { part.delete() }
+            .onFailure { deleteQuietly(part) }
             .getOrThrow()
         if (saved && part.renameTo(target)) {
             dao.upsert(track.toDownloadedTrack(id, target.path, target.length()))
         } else {
-            part.delete()
+            deleteQuietly(part)
         }
+    }
+
+    /** Best-effort delete that consumes [File.delete]'s result, logging when a file can't be removed. */
+    private fun deleteQuietly(file: File) {
+        if (file.exists() && !file.delete()) Log.w(TAG, "Could not delete ${file.name}")
     }
 
     /** The stream URL to download for [id], or null if it is already saved or storage is low. */

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadManager.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadManager.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.compose.ui.graphics.toArgb
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
@@ -19,7 +20,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.ResponseBody
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
-import pe.net.libre.mixtapehaven.data.playback.PlayerController
 import pe.net.libre.mixtapehaven.model.Track
 import java.io.File
 import java.io.InputStream
@@ -31,16 +31,16 @@ data class DownloadProgress(val track: Track, val percent: Int)
 
 /**
  * App-scoped service that saves the original file bytes of tracks as they play, so the library
- * becomes available offline. Observes [PlayerController.nowPlaying]; when auto-download is enabled
- * it streams the static original file from [repository] to internal storage and records a
- * [DownloadedTrack] row. Failures never crash playback and already-saved tracks are skipped.
+ * becomes available offline. Driven by a now-playing [Flow] (passed to [start] to avoid a
+ * dependency cycle with the player); when auto-download is enabled it streams the static original
+ * file from [repository] to internal storage and records a [DownloadedTrack] row. Failures never
+ * crash playback and already-saved tracks are skipped.
  */
 class DownloadManager(
     context: Context,
     private val repository: JellyfinRepository,
     private val dao: DownloadDao,
     private val settingsStore: DownloadSettingsStore,
-    private val playerController: PlayerController,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
     private val client: OkHttpClient = OkHttpClient(),
 ) {
@@ -63,10 +63,14 @@ class DownloadManager(
     @Volatile
     private var completedPaths: Map<String, String> = emptyMap()
 
-    private val inProgress: MutableSet<String> = Collections.synchronizedSet(mutableSetOf())
+    /** Active download coroutines keyed by track id, so they can be cancelled (e.g. on removeAll). */
+    private val activeJobs: MutableMap<String, Job> = Collections.synchronizedMap(mutableMapOf())
 
-    /** Begin observing settings, the saved library, and playback. Idempotent per instance. */
-    fun start() {
+    /**
+     * Begin observing settings, the saved library, and the [nowPlaying] stream (supplied by the
+     * caller to avoid a cycle with the player). Idempotent per instance.
+     */
+    fun start(nowPlaying: Flow<Track?>) {
         scope.launch { settingsStore.autoDownloadEnabled.collect { autoDownloadEnabled = it } }
         scope.launch {
             dao.observeAll().collect { rows ->
@@ -74,13 +78,13 @@ class DownloadManager(
             }
         }
         scope.launch {
-            playerController.nowPlaying.collect { track -> track?.let(::onTrackPlaying) }
+            nowPlaying.collect { track -> track?.let(::onTrackPlaying) }
         }
     }
 
     /**
      * Local playback URI for [track] if its bytes are saved, else null. Synchronous (in-memory
-     * lookup) so it can back [PlayerController.streamUrlResolver] when media items are built.
+     * lookup) so it can back the player's stream-URL resolver when media items are built.
      */
     fun localUriFor(track: Track): String? {
         val path = track.id?.let { completedPaths[it] } ?: return null
@@ -91,28 +95,36 @@ class DownloadManager(
     /** Usable bytes remaining on the volume backing the download directory. */
     fun usableSpaceBytes(): Long = downloadsDir.usableSpace
 
-    /** Delete every saved file and clear the download library. */
+    /** Cancel in-flight downloads, delete every saved file, and clear the download library. */
     suspend fun removeAll() {
-        val rows = dao.getAll()
+        // Stop active downloads first so nothing writes a file or row after the cleanup below.
+        val jobs = synchronized(activeJobs) {
+            activeJobs.values.toList().also { activeJobs.clear() }
+        }
+        jobs.forEach { it.cancel() }
+        jobs.forEach { runCatching { it.join() } }
+        _progress.value = null
         dao.clear()
         withContext(Dispatchers.IO) {
-            rows.forEach { runCatching { File(it.filePath).delete() } }
+            // Wipe the directory wholesale to also catch any orphaned/partial (.part) files.
+            downloadsDir.listFiles()?.forEach { runCatching { it.delete() } }
         }
         completedPaths = emptyMap()
-        _progress.value = null
     }
 
     private fun onTrackPlaying(track: Track) {
         val id = track.id
-        if (!autoDownloadEnabled || id == null) return
-        if (completedPaths.containsKey(id) || !inProgress.add(id)) return
-        scope.launch {
-            try {
-                runCatching { download(track, id) }
-                    .onFailure { Log.w(TAG, "Download failed for $id", it) }
-            } finally {
-                inProgress.remove(id)
-                if (_progress.value?.track?.id == id) _progress.value = null
+        if (!autoDownloadEnabled || id == null || completedPaths.containsKey(id)) return
+        synchronized(activeJobs) {
+            if (activeJobs.containsKey(id)) return
+            activeJobs[id] = scope.launch {
+                try {
+                    runCatching { download(track, id) }
+                        .onFailure { Log.w(TAG, "Download failed for $id", it) }
+                } finally {
+                    activeJobs.remove(id)
+                    if (_progress.value?.track?.id == id) _progress.value = null
+                }
             }
         }
     }
@@ -143,8 +155,7 @@ class DownloadManager(
     private suspend fun streamToFile(url: String, part: File, track: Track): Boolean {
         val request = Request.Builder().url(url).build()
         return client.newCall(request).execute().use { response ->
-            val body = response.body
-            if (!response.isSuccessful || body == null) false else copyToFile(body, part, track)
+            if (!response.isSuccessful) false else copyToFile(response.body, part, track)
         }
     }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadSettingsStore.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadSettingsStore.kt
@@ -1,0 +1,30 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.downloadSettingsDataStore: DataStore<Preferences> by
+    preferencesDataStore(name = "download_settings")
+
+/** Persists download preferences (auto-download enabled) across app launches via DataStore. */
+class DownloadSettingsStore(private val context: Context) {
+
+    private object Keys {
+        val AUTO_DOWNLOAD = booleanPreferencesKey("auto_download_enabled")
+    }
+
+    /** Whether tracks are saved for offline automatically as they play. Defaults to enabled. */
+    val autoDownloadEnabled: Flow<Boolean> = context.downloadSettingsDataStore.data.map { prefs ->
+        prefs[Keys.AUTO_DOWNLOAD] ?: true
+    }
+
+    suspend fun setAutoDownloadEnabled(enabled: Boolean) {
+        context.downloadSettingsDataStore.edit { it[Keys.AUTO_DOWNLOAD] = enabled }
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadedTrack.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadedTrack.kt
@@ -1,0 +1,36 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import androidx.compose.ui.graphics.Color
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import pe.net.libre.mixtapehaven.model.Track
+
+/**
+ * A track whose original file bytes have been saved to local storage for offline playback.
+ * [artColorArgb] is the packed ARGB of the vinyl-tint fallback. [complete] is false while the
+ * bytes are still being written (a partial download) and true once the file is fully saved.
+ */
+@Entity(tableName = "downloaded_tracks")
+data class DownloadedTrack(
+    @PrimaryKey val id: String,
+    val title: String,
+    val artist: String,
+    val durationLabel: String,
+    val imageUrl: String?,
+    val artColorArgb: Int,
+    val filePath: String,
+    val sizeBytes: Long,
+    val complete: Boolean,
+)
+
+/** Map a persisted download back to a UI [Track], flagged as downloaded with a human-readable size. */
+internal fun DownloadedTrack.toTrack(): Track = Track(
+    title = title,
+    artist = artist,
+    durationLabel = durationLabel,
+    artColor = Color(artColorArgb),
+    downloaded = true,
+    sizeLabel = formatBytes(sizeBytes),
+    id = id,
+    imageUrl = imageUrl,
+)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
@@ -4,6 +4,10 @@ import android.content.Context
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.createJellyfin
 import org.jellyfin.sdk.model.ClientInfo
+import pe.net.libre.mixtapehaven.data.download.DownloadDatabase
+import pe.net.libre.mixtapehaven.data.download.DownloadManager
+import pe.net.libre.mixtapehaven.data.download.DownloadSettingsStore
+import pe.net.libre.mixtapehaven.data.download.resolveLocalFirst
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
 import pe.net.libre.mixtapehaven.data.playback.PlayerController
 import pe.net.libre.mixtapehaven.data.session.SessionStore
@@ -22,5 +26,31 @@ class AppContainer(context: Context) {
 
     val repository: JellyfinRepository = JellyfinRepository(jellyfin, sessionStore)
 
-    val playerController: PlayerController by lazy { PlayerController(appContext, repository) }
+    val downloadSettingsStore: DownloadSettingsStore = DownloadSettingsStore(appContext)
+
+    private val downloadDatabase: DownloadDatabase by lazy { DownloadDatabase.build(appContext) }
+
+    val playerController: PlayerController by lazy {
+        PlayerController(appContext, repository).also { controller ->
+            // Local-first: serve saved bytes when present, else fall back to the remote stream.
+            controller.streamUrlResolver = { track ->
+                resolveLocalFirst(track, downloadManager::localUriFor, repository::audioStreamUrl)
+            }
+        }
+    }
+
+    val downloadManager: DownloadManager by lazy {
+        DownloadManager(
+            context = appContext,
+            repository = repository,
+            dao = downloadDatabase.downloadDao(),
+            settingsStore = downloadSettingsStore,
+            playerController = playerController,
+        ).also { it.start() }
+    }
+
+    init {
+        // Eagerly start auto-download so playback is captured even before any download UI is opened.
+        downloadManager
+    }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
@@ -30,14 +30,7 @@ class AppContainer(context: Context) {
 
     private val downloadDatabase: DownloadDatabase by lazy { DownloadDatabase.build(appContext) }
 
-    val playerController: PlayerController by lazy {
-        PlayerController(appContext, repository).also { controller ->
-            // Local-first: serve saved bytes when present, else fall back to the remote stream.
-            controller.streamUrlResolver = { track ->
-                resolveLocalFirst(track, downloadManager::localUriFor, repository::audioStreamUrl)
-            }
-        }
-    }
+    val playerController: PlayerController by lazy { PlayerController(appContext, repository) }
 
     val downloadManager: DownloadManager by lazy {
         DownloadManager(
@@ -45,12 +38,18 @@ class AppContainer(context: Context) {
             repository = repository,
             dao = downloadDatabase.downloadDao(),
             settingsStore = downloadSettingsStore,
-            playerController = playerController,
-        ).also { it.start() }
+        )
     }
 
     init {
-        // Eagerly start auto-download so playback is captured even before any download UI is opened.
-        downloadManager
+        // Wire the two app-scoped singletons after both are built, so neither depends on the other
+        // at construction time. Eager so auto-download runs before any download UI is opened.
+        val manager = downloadManager
+        val controller = playerController
+        // Local-first: serve saved bytes when present, else fall back to the remote stream.
+        controller.streamUrlResolver = { track ->
+            resolveLocalFirst(track, manager::localUriFor, repository::audioStreamUrl)
+        }
+        manager.start(controller.nowPlaying)
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsScreen.kt
@@ -17,20 +17,21 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDownward
 import androidx.compose.material.icons.outlined.DeleteOutline
-import androidx.compose.material.icons.outlined.MoreVert
-import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import pe.net.libre.mixtapehaven.model.SampleData
+import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.ui.components.BackTopBar
 import pe.net.libre.mixtapehaven.ui.components.SectionLabel
 import pe.net.libre.mixtapehaven.ui.components.StorageBar
@@ -44,6 +45,9 @@ import pe.net.libre.mixtapehaven.ui.theme.TextSecondary
 
 @Composable
 fun DownloadsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
+    val viewModel = appViewModel { DownloadsViewModel(it.downloadManager) }
+    val state by viewModel.state.collectAsState()
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -64,92 +68,100 @@ fun DownloadsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text("Mixtape downloads", style = MaterialTheme.typography.titleMedium, color = TextPrimary)
-                Text("1.8 GB", style = MaterialTheme.typography.titleMedium, color = TextSecondary)
+                Text(state.totalLabel, style = MaterialTheme.typography.titleMedium, color = TextSecondary)
             }
-            StorageBar(segments = listOf(0.5f to Accent, 0.35f to Coral))
-            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                LegendItem(Accent, "Auto-saved 1.0 GB")
-                LegendItem(Coral, "Pinned 0.8 GB")
-            }
+            StorageBar(segments = listOf(state.usedFraction to Accent))
+            LegendItem(Accent, "Saved as you listen · ${state.totalLabel}")
         }
 
-        SectionLabel("DOWNLOADING")
-
-        TrackRow(
-            track = SampleData.downloading,
-            trailing = {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Text("68%", style = MaterialTheme.typography.bodySmall, color = Accent)
-                    CircularProgressIndicator(
-                        progress = { 0.68f },
-                        color = Accent,
-                        trackColor = Surface2,
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                    )
-                }
-            },
-        )
+        val downloading = state.downloading
+        if (downloading != null) {
+            SectionLabel("DOWNLOADING")
+            TrackRow(
+                track = downloading.track,
+                trailing = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            "${downloading.percent}%",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Accent,
+                        )
+                        CircularProgressIndicator(
+                            progress = { downloading.percent / 100f },
+                            color = Accent,
+                            trackColor = Surface2,
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    }
+                },
+            )
+        }
 
         SectionLabel("SAVED ON DEVICE")
 
-        Column {
-            SampleData.downloads.forEachIndexed { index, track ->
-                TrackRow(
-                    track = track,
-                    trailing = {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            Text(track.sizeLabel, style = MaterialTheme.typography.bodySmall, color = TextMuted)
-                            if (index == 0) {
+        if (state.saved.isEmpty()) {
+            Text(
+                "Nothing saved yet. Play anything and it's kept for offline automatically.",
+                style = MaterialTheme.typography.bodySmall,
+                color = TextMuted,
+            )
+        } else {
+            Column {
+                state.saved.forEach { track ->
+                    TrackRow(
+                        track = track,
+                        trailing = {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                Text(
+                                    track.sizeLabel,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = TextMuted,
+                                )
                                 Icon(
-                                    Icons.Outlined.PushPin,
-                                    contentDescription = "Pinned",
+                                    Icons.Outlined.ArrowDownward,
+                                    contentDescription = "Saved offline",
                                     tint = Accent,
                                     modifier = Modifier.size(18.dp),
                                 )
-                            } else {
-                                Icon(
-                                    Icons.Outlined.MoreVert,
-                                    contentDescription = "More",
-                                    tint = TextMuted,
-                                    modifier = Modifier.size(18.dp),
-                                )
                             }
-                        }
-                    },
-                )
+                        },
+                    )
+                }
             }
         }
 
         // Destructive: remove all downloads
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(14.dp))
-                .border(1.dp, Coral, RoundedCornerShape(14.dp))
-                .clickable { /* no-op */ }
-                .padding(vertical = 14.dp),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                Icons.Outlined.DeleteOutline,
-                contentDescription = null,
-                tint = Coral,
-                modifier = Modifier.size(20.dp),
-            )
-            Text(
-                "Remove all downloads",
-                style = MaterialTheme.typography.titleMedium,
-                color = Coral,
-                modifier = Modifier.padding(start = 8.dp),
-            )
+        if (state.saved.isNotEmpty() || state.downloading != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(14.dp))
+                    .border(1.dp, Coral, RoundedCornerShape(14.dp))
+                    .clickable(onClick = viewModel::removeAll)
+                    .padding(vertical = 14.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Outlined.DeleteOutline,
+                    contentDescription = null,
+                    tint = Coral,
+                    modifier = Modifier.size(20.dp),
+                )
+                Text(
+                    "Remove all downloads",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = Coral,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsViewModel.kt
@@ -1,0 +1,54 @@
+package pe.net.libre.mixtapehaven.ui.screens.downloads
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.data.download.DownloadManager
+import pe.net.libre.mixtapehaven.data.download.DownloadProgress
+import pe.net.libre.mixtapehaven.data.download.formatBytes
+import pe.net.libre.mixtapehaven.data.download.toTrack
+import pe.net.libre.mixtapehaven.model.Track
+
+/** Backs the Downloads screen with the real saved library, in-flight progress, and storage totals. */
+class DownloadsViewModel(
+    private val downloadManager: DownloadManager,
+) : ViewModel() {
+
+    data class UiState(
+        val downloading: DownloadProgress? = null,
+        val saved: List<Track> = emptyList(),
+        val totalLabel: String = formatBytes(0),
+        val usedFraction: Float = 0f,
+    )
+
+    val state: StateFlow<UiState> =
+        combine(downloadManager.downloads, downloadManager.progress) { rows, progress ->
+            val completed = rows.filter { it.complete }
+            val totalBytes = completed.sumOf { it.sizeBytes }
+            UiState(
+                downloading = progress,
+                saved = completed.map { it.toTrack() },
+                totalLabel = formatBytes(totalBytes),
+                usedFraction = usedFractionOf(totalBytes, downloadManager.usableSpaceBytes()),
+            )
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), UiState())
+
+    fun removeAll() {
+        viewModelScope.launch { downloadManager.removeAll() }
+    }
+
+    private companion object {
+        const val STOP_TIMEOUT_MS = 5_000L
+    }
+}
+
+/** Fraction of the storage bar to fill: used bytes over (used + free), clamped to a sane minimum. */
+internal fun usedFractionOf(usedBytes: Long, freeBytes: Long): Float {
+    val capacity = usedBytes + freeBytes
+    if (capacity <= 0L || usedBytes <= 0L) return 0f
+    return (usedBytes.toFloat() / capacity).coerceIn(0f, 1f)
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsViewModel.kt
@@ -2,11 +2,13 @@ package pe.net.libre.mixtapehaven.ui.screens.downloads
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.download.DownloadProgress
 import pe.net.libre.mixtapehaven.data.download.formatBytes
@@ -27,14 +29,17 @@ class DownloadsViewModel(
 
     val state: StateFlow<UiState> =
         combine(downloadManager.downloads, downloadManager.progress) { rows, progress ->
-            val completed = rows.filter { it.complete }
-            val totalBytes = completed.sumOf { it.sizeBytes }
-            UiState(
-                downloading = progress,
-                saved = completed.map { it.toTrack() },
-                totalLabel = formatBytes(totalBytes),
-                usedFraction = usedFractionOf(totalBytes, downloadManager.usableSpaceBytes()),
-            )
+            // Mapping + File.usableSpace touch disk; keep them off the Main thread.
+            withContext(Dispatchers.IO) {
+                val completed = rows.filter { it.complete }
+                val totalBytes = completed.sumOf { it.sizeBytes }
+                UiState(
+                    downloading = progress,
+                    saved = completed.map { it.toTrack() },
+                    totalLabel = formatBytes(totalBytes),
+                    usedFraction = usedFractionOf(totalBytes, downloadManager.usableSpaceBytes()),
+                )
+            }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), UiState())
 
     fun removeAll() {

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -34,12 +34,14 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.model.Album
+import pe.net.libre.mixtapehaven.model.Track
 import pe.net.libre.mixtapehaven.ui.components.AlbumCard
 import pe.net.libre.mixtapehaven.ui.components.RandomWalkCard
 import pe.net.libre.mixtapehaven.ui.components.SearchField
 import pe.net.libre.mixtapehaven.ui.components.SectionHeader
 import pe.net.libre.mixtapehaven.ui.components.StatusPill
 import pe.net.libre.mixtapehaven.ui.components.SurfaceCard
+import pe.net.libre.mixtapehaven.ui.components.TrackRow
 import pe.net.libre.mixtapehaven.ui.theme.Accent
 import pe.net.libre.mixtapehaven.ui.theme.Stroke
 import pe.net.libre.mixtapehaven.ui.theme.Surface2
@@ -55,8 +57,9 @@ fun HomeScreen(
     onOpenNowPlaying: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val viewModel = appViewModel { HomeViewModel(it.repository, it.playerController) }
+    val viewModel = appViewModel { HomeViewModel(it.repository, it.playerController, it.downloadManager) }
     val state by viewModel.state.collectAsState()
+    val hasDownloads = state.onDevice.isNotEmpty()
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -69,39 +72,11 @@ fun HomeScreen(
     ) {
         Spacer(Modifier.size(0.dp))
 
-        // Header row
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.Top,
-        ) {
-            Column {
-                Text(
-                    "Good evening",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = TextSecondary,
-                )
-                Text(
-                    state.userName.ifBlank { "Mixtape" },
-                    style = MaterialTheme.typography.displayMedium,
-                    color = TextPrimary,
-                )
-            }
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                StatusPill(text = "Online", dotColor = Color(0xFF7BB661))
-                Icon(
-                    Icons.Outlined.Settings,
-                    contentDescription = "Settings",
-                    tint = TextSecondary,
-                    modifier = Modifier
-                        .size(24.dp)
-                        .clickable(onClick = onOpenSettings),
-                )
-            }
-        }
+        HomeHeader(
+            userName = state.userName,
+            hasDownloads = hasDownloads,
+            onOpenSettings = onOpenSettings,
+        )
 
         RandomWalkCard(
             onPlay = {
@@ -114,6 +89,17 @@ fun HomeScreen(
             placeholder = "Search songs, albums, artists",
             onClick = onOpenSearch,
         )
+
+        if (hasDownloads) {
+            OnDeviceSection(
+                tracks = state.onDevice,
+                onManage = onOpenDownloads,
+                onPlay = { track ->
+                    viewModel.playOnDevice(track)
+                    onOpenNowPlaying()
+                },
+            )
+        }
 
         SectionHeader(
             title = "Recently added",
@@ -131,6 +117,70 @@ fun HomeScreen(
                     onOpenNowPlaying()
                 },
             )
+        }
+    }
+}
+
+/** Max number of saved tracks previewed in the Home "On your device" section. */
+private const val ON_DEVICE_PREVIEW = 4
+
+@Composable
+private fun HomeHeader(
+    userName: String,
+    hasDownloads: Boolean,
+    onOpenSettings: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Top,
+    ) {
+        Column {
+            Text(
+                "Good evening",
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
+            )
+            Text(
+                userName.ifBlank { "Mixtape" },
+                style = MaterialTheme.typography.displayMedium,
+                color = TextPrimary,
+            )
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            StatusPill(
+                text = if (hasDownloads) "Offline ready" else "Online",
+                dotColor = if (hasDownloads) Accent else Color(0xFF7BB661),
+            )
+            Icon(
+                Icons.Outlined.Settings,
+                contentDescription = "Settings",
+                tint = TextSecondary,
+                modifier = Modifier
+                    .size(24.dp)
+                    .clickable(onClick = onOpenSettings),
+            )
+        }
+    }
+}
+
+@Composable
+private fun OnDeviceSection(
+    tracks: List<Track>,
+    onManage: () -> Unit,
+    onPlay: (Track) -> Unit,
+) {
+    SectionHeader(
+        title = "On your device",
+        actionLabel = "Manage",
+        onAction = onManage,
+    )
+    Column {
+        tracks.take(ON_DEVICE_PREVIEW).forEach { track ->
+            TrackRow(track = track, onClick = { onPlay(track) })
         }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -2,12 +2,14 @@ package pe.net.libre.mixtapehaven.ui.screens.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.download.toTrack
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
@@ -64,7 +66,10 @@ class HomeViewModel(
     private fun observeDownloads() {
         viewModelScope.launch {
             downloadManager.downloads.collect { rows ->
-                val tracks = rows.filter { it.complete }.map { it.toTrack() }
+                // Mapping rows -> Track is cheap but kept off Main to stay consistent with the DAO.
+                val tracks = withContext(Dispatchers.IO) {
+                    rows.filter { it.complete }.map { it.toTrack() }
+                }
                 _state.update { it.copy(onDevice = tracks) }
             }
         }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -8,20 +8,25 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.data.download.DownloadManager
+import pe.net.libre.mixtapehaven.data.download.toTrack
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
 import pe.net.libre.mixtapehaven.data.playback.PlaybackSource
 import pe.net.libre.mixtapehaven.data.playback.PlayerController
 import pe.net.libre.mixtapehaven.data.playback.RandomWalk
 import pe.net.libre.mixtapehaven.model.Album
+import pe.net.libre.mixtapehaven.model.Track
 
 class HomeViewModel(
     private val repository: JellyfinRepository,
     private val playerController: PlayerController,
+    private val downloadManager: DownloadManager,
 ) : ViewModel() {
 
     data class UiState(
         val userName: String = "",
         val albums: List<Album> = emptyList(),
+        val onDevice: List<Track> = emptyList(),
         val loading: Boolean = true,
         val error: String? = null,
     )
@@ -31,6 +36,7 @@ class HomeViewModel(
 
     init {
         load()
+        observeDownloads()
     }
 
     fun load() {
@@ -54,6 +60,16 @@ class HomeViewModel(
         }
     }
 
+    /** Keep the "On your device" section in sync with the offline library. */
+    private fun observeDownloads() {
+        viewModelScope.launch {
+            downloadManager.downloads.collect { rows ->
+                val tracks = rows.filter { it.complete }.map { it.toTrack() }
+                _state.update { it.copy(onDevice = tracks) }
+            }
+        }
+    }
+
     /** Load the album's tracks and start playback from the first one. */
     fun playAlbum(album: Album) {
         val albumId = album.id ?: return
@@ -71,5 +87,12 @@ class HomeViewModel(
         viewModelScope.launch {
             runCatching { RandomWalk(repository, playerController).start() }
         }
+    }
+
+    /** Play the offline library starting from [track] (serves from local files first). */
+    fun playOnDevice(track: Track) {
+        val tracks = _state.value.onDevice
+        val startIndex = tracks.indexOfFirst { it.id == track.id }.coerceAtLeast(0)
+        if (tracks.isNotEmpty()) playerController.play(tracks, startIndex)
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingScreen.kt
@@ -49,12 +49,14 @@ import pe.net.libre.mixtapehaven.ui.theme.TextSecondary
 
 @Composable
 fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
-    val viewModel = appViewModel { NowPlayingViewModel(it.playerController) }
+    val viewModel = appViewModel { NowPlayingViewModel(it.playerController, it.downloadManager) }
     val track by viewModel.nowPlaying.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
     val positionMs by viewModel.positionMs.collectAsState()
     val durationMs by viewModel.durationMs.collectAsState()
     val source by viewModel.source.collectAsState()
+    val savingPercent by viewModel.savingPercent.collectAsState()
+    val offlineReady by viewModel.offlineReady.collectAsState()
 
     val progress = if (durationMs > 0) (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
 
@@ -122,6 +124,7 @@ fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 style = MaterialTheme.typography.bodyLarge,
                 color = TextSecondary,
             )
+            OfflineStatus(savingPercent = savingPercent, offlineReady = offlineReady)
         }
 
         // Progress
@@ -192,6 +195,28 @@ fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
         }
     }
 }
+
+/** "SAVING OFFLINE · N%" while the current track downloads; "OFFLINE READY" once saved. */
+@Composable
+private fun OfflineStatus(savingPercent: Int?, offlineReady: Boolean, modifier: Modifier = Modifier) {
+    when {
+        savingPercent != null -> Text(
+            "SAVING OFFLINE · $savingPercent%",
+            modifier = modifier,
+            style = MaterialTheme.typography.labelMedium,
+            color = Accent,
+        )
+
+        offlineReady -> Text(
+            "OFFLINE READY",
+            modifier = modifier,
+            style = MaterialTheme.typography.labelMedium,
+            color = OfflineReadyGreen,
+        )
+    }
+}
+
+private val OfflineReadyGreen = androidx.compose.ui.graphics.Color(0xFF7BB661)
 
 private fun formatTime(ms: Long): String {
     if (ms <= 0) return "0:00"

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingViewModel.kt
@@ -1,13 +1,19 @@
 package pe.net.libre.mixtapehaven.ui.screens.nowplaying
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.playback.PlaybackSource
 import pe.net.libre.mixtapehaven.data.playback.PlayerController
 import pe.net.libre.mixtapehaven.model.Track
-import kotlinx.coroutines.flow.StateFlow
 
 class NowPlayingViewModel(
     private val playerController: PlayerController,
+    downloadManager: DownloadManager,
 ) : ViewModel() {
 
     val nowPlaying: StateFlow<Track?> = playerController.nowPlaying
@@ -16,8 +22,24 @@ class NowPlayingViewModel(
     val durationMs: StateFlow<Long> = playerController.durationMs
     val source: StateFlow<PlaybackSource> = playerController.source
 
+    /** Save percent (0-100) when the current track is being downloaded, else null. */
+    val savingPercent: StateFlow<Int?> =
+        combine(playerController.nowPlaying, downloadManager.progress) { track, progress ->
+            if (progress != null && progress.track.id == track?.id) progress.percent else null
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), null)
+
+    /** True when the current track is already saved for offline playback. */
+    val offlineReady: StateFlow<Boolean> =
+        combine(playerController.nowPlaying, downloadManager.downloads) { track, rows ->
+            track?.id != null && rows.any { it.id == track.id && it.complete }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), false)
+
     fun playPause() = playerController.playPause()
     fun next() = playerController.next()
     fun previous() = playerController.previous()
     fun seekToFraction(fraction: Float) = playerController.seekToFraction(fraction)
+
+    private companion object {
+        const val STOP_TIMEOUT_MS = 5_000L
+    }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,6 +33,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.model.SampleData
 import pe.net.libre.mixtapehaven.ui.components.BackTopBar
 import pe.net.libre.mixtapehaven.ui.components.SectionLabel
@@ -53,7 +55,9 @@ fun SettingsScreen(
     onSignOut: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var automaticDownloads by remember { mutableStateOf(true) }
+    val viewModel = appViewModel { SettingsViewModel(it.downloadSettingsStore, it.downloadManager) }
+    val automaticDownloads by viewModel.autoDownloadEnabled.collectAsState()
+    val storageUsed by viewModel.storageUsedLabel.collectAsState()
     var wifiOnly by remember { mutableStateOf(true) }
 
     Column(
@@ -104,7 +108,7 @@ fun SettingsScreen(
                     title = "Automatic downloads",
                     subtitle = "Keep songs for offline as you play them",
                     checked = automaticDownloads,
-                    onCheckedChange = { automaticDownloads = it },
+                    onCheckedChange = viewModel::setAutoDownloadEnabled,
                 )
                 HorizontalDivider(color = Stroke)
                 SettingToggleRow(
@@ -116,7 +120,7 @@ fun SettingsScreen(
                 HorizontalDivider(color = Stroke)
                 SettingLinkRow(title = "Audio quality", value = "Lossless", onClick = {})
                 HorizontalDivider(color = Stroke)
-                SettingLinkRow(title = "Storage used", value = "1.2 GB", onClick = onOpenDownloads)
+                SettingLinkRow(title = "Storage used", value = storageUsed, onClick = onOpenDownloads)
             }
         }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsViewModel.kt
@@ -1,0 +1,36 @@
+package pe.net.libre.mixtapehaven.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.data.download.DownloadManager
+import pe.net.libre.mixtapehaven.data.download.DownloadSettingsStore
+import pe.net.libre.mixtapehaven.data.download.formatBytes
+
+/** Backs the Settings screen: persists the auto-download toggle and surfaces real storage usage. */
+class SettingsViewModel(
+    private val settingsStore: DownloadSettingsStore,
+    downloadManager: DownloadManager,
+) : ViewModel() {
+
+    val autoDownloadEnabled: StateFlow<Boolean> =
+        settingsStore.autoDownloadEnabled
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), true)
+
+    val storageUsedLabel: StateFlow<String> =
+        downloadManager.totalSizeBytes
+            .map { formatBytes(it) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), formatBytes(0))
+
+    fun setAutoDownloadEnabled(enabled: Boolean) {
+        viewModelScope.launch { settingsStore.setAutoDownloadEnabled(enabled) }
+    }
+
+    private companion object {
+        const val STOP_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/download/DownloadManagerLogicTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/download/DownloadManagerLogicTest.kt
@@ -1,0 +1,79 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import pe.net.libre.mixtapehaven.model.Track
+
+/** Unit coverage for the pure download/local-first logic introduced for #129. */
+class DownloadManagerLogicTest {
+
+    private fun track(id: String?) =
+        Track(title = "t", artist = "a", durationLabel = "0:00", artColor = Color(0xFF000000), id = id)
+
+    @Test
+    fun `resolveLocalFirst prefers the local file when downloaded`() {
+        val downloaded = mapOf("1" to "file:///data/1")
+
+        val url = resolveLocalFirst(
+            track = track("1"),
+            localUri = { downloaded[it.id] },
+            streamUrl = { "stream://$it" },
+        )
+
+        assertEquals("file:///data/1", url)
+    }
+
+    @Test
+    fun `resolveLocalFirst falls back to the stream when not downloaded`() {
+        val downloaded = emptyMap<String, String>()
+
+        val url = resolveLocalFirst(
+            track = track("2"),
+            localUri = { downloaded[it.id] },
+            streamUrl = { "stream://$it" },
+        )
+
+        assertEquals("stream://2", url)
+    }
+
+    @Test
+    fun `resolveLocalFirst returns null when there is no id and no local file`() {
+        val url = resolveLocalFirst(
+            track = track(null),
+            localUri = { null },
+            streamUrl = { "stream://$it" },
+        )
+
+        assertNull(url)
+    }
+
+    @Test
+    fun `shouldStartDownload only starts when free space exceeds the floor`() {
+        assertTrue(shouldStartDownload(freeBytes = 500_000_000, minFreeBytes = 200_000_000))
+        assertFalse(shouldStartDownload(freeBytes = 100_000_000, minFreeBytes = 200_000_000))
+        assertFalse(shouldStartDownload(freeBytes = 200_000_000, minFreeBytes = 200_000_000))
+    }
+
+    @Test
+    fun `percentOf clamps and handles unknown totals`() {
+        assertEquals(0, percentOf(downloaded = 0, total = 100))
+        assertEquals(50, percentOf(downloaded = 50, total = 100))
+        assertEquals(100, percentOf(downloaded = 100, total = 100))
+        // Unknown content length reports 0% rather than crashing.
+        assertEquals(0, percentOf(downloaded = 50, total = -1))
+        // Never exceeds 100 even if more bytes arrive than advertised.
+        assertEquals(100, percentOf(downloaded = 150, total = 100))
+    }
+
+    @Test
+    fun `formatBytes renders human-readable sizes`() {
+        assertEquals("0 MB", formatBytes(0))
+        assertEquals("9.8 MB", formatBytes(9_800_000))
+        assertEquals("14 MB", formatBytes(14_000_000))
+        assertEquals("1.2 GB", formatBytes(1_200_000_000))
+    }
+}


### PR DESCRIPTION
Closes #129.

Implements **auto-download**: as tracks play, the original file bytes are saved locally so the library becomes available offline ("local-first"). Built on the `streamUrlResolver` seam from #130/#131 (does not touch `play()`).

## Design
- **Persistence (Room):** `DownloadedTrack` entity (id PK, title, artist, durationLabel, imageUrl, artColorArgb, filePath, sizeBytes, complete) + `DownloadDao` (observeAll, observeTotalSize, upsert, findById, getAll, deleteById, clear). `DownloadDatabase.build()` wired through `AppContainer` (manual DI, no Hilt). KSP plugin + Room deps added to `app/build.gradle.kts`.
- **DownloadManager:** app-scoped (IO + SupervisorJob). Observes settings, Room rows (into an in-memory id→path cache), and `playerController.nowPlaying`. Streams the static original file (OkHttp) to `filesDir/downloads/<id>.part`, renames on success, upserts the row. Skips already-saved tracks, dedupes in-flight downloads, is storage-quota aware, emits per-track progress, and never crashes on failure (partial-file cleanup).
- **Local-first resolver:** `AppContainer` sets `streamUrlResolver = { resolveLocalFirst(track, downloadManager::localUriFor, repository::audioStreamUrl) }` — synchronous in-memory lookup returns a `file://` URI when saved, else falls back to the remote stream.
- **Settings toggle:** persisted in a DataStore-backed `DownloadSettingsStore`; DownloadManager respects it before each download.
- **UI wired to real data (replacing `SampleData`):** Downloads screen (`DownloadsViewModel` — real downloading item/%, saved list, total storage, working "remove all"), Home "On your device" section + "Offline ready" pill, Now Playing "SAVING OFFLINE · %" indicator, Settings toggle.

## Tests
- Pure-function unit coverage mirroring the existing seam tests: `resolveLocalFirst`, `shouldStartDownload` (quota), `percentOf`, `formatBytes` (6 tests, all passing). Room DAO tests are instrumented-only and intentionally omitted to avoid flakiness.
- `assembleDebug`, `detekt`, `test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)