### PR TITLE
Add devcontainer config for NAS dev environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "mixtapehaven-android",
+  "image": "mcr.microsoft.com/devcontainers/java:17-bookworm",
+  "containerEnv": {
+    "ANDROID_HOME": "/home/vscode/android-sdk",
+    "ANDROID_SDK_ROOT": "/home/vscode/android-sdk"
+  },
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:/home/vscode/android-sdk/cmdline-tools/latest/bin:/home/vscode/android-sdk/platform-tools"
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "mounts": [
+    "source=gradle-cache,target=/home/vscode/.gradle,type=volume",
+    "source=android-sdk,target=/home/vscode/android-sdk,type=volume"
+  ],
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "fwcd.kotlin"
+      ]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,6 +8,7 @@ ANDROID_HOME="${ANDROID_HOME:-$HOME/android-sdk}"
 CMDLINE_TOOLS_VERSION="11076708"  # "latest" as of 2024-01; pinned for reproducibility
 SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
 
+mkdir -p "$ANDROID_HOME"
 sudo chown -R "$(id -u):$(id -g)" "$ANDROID_HOME"
 
 if [ ! -x "$SDKMANAGER" ]; then
@@ -16,15 +17,18 @@ if [ ! -x "$SDKMANAGER" ]; then
   curl -fsSL -o "$tmp/tools.zip" \
     "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
   unzip -q "$tmp/tools.zip" -d "$tmp"
+  rm -rf "$ANDROID_HOME/cmdline-tools/latest"
   mkdir -p "$ANDROID_HOME/cmdline-tools"
   mv "$tmp/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest"
   rm -rf "$tmp"
 fi
 
 yes | "$SDKMANAGER" --licenses > /dev/null || true
+# compileSdk is release(37) in app/build.gradle.kts; platform 37 ships under
+# the minor-versioned name "android-37.0"
 "$SDKMANAGER" --install \
   "platform-tools" \
-  "platforms;android-36" \
-  "build-tools;36.0.0"
+  "platforms;android-37.0" \
+  "build-tools;37.0.0"
 
 echo "Android SDK ready at $ANDROID_HOME"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Install the Android SDK (cmdline-tools + platform for this project) into
+# $ANDROID_HOME. Idempotent: the SDK lives on a named volume, so re-creating
+# the container skips the download.
+set -euo pipefail
+
+ANDROID_HOME="${ANDROID_HOME:-$HOME/android-sdk}"
+CMDLINE_TOOLS_VERSION="11076708"  # "latest" as of 2024-01; pinned for reproducibility
+SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+
+sudo chown -R "$(id -u):$(id -g)" "$ANDROID_HOME"
+
+if [ ! -x "$SDKMANAGER" ]; then
+  echo "Installing Android cmdline-tools..."
+  tmp=$(mktemp -d)
+  curl -fsSL -o "$tmp/tools.zip" \
+    "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+  unzip -q "$tmp/tools.zip" -d "$tmp"
+  mkdir -p "$ANDROID_HOME/cmdline-tools"
+  mv "$tmp/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest"
+  rm -rf "$tmp"
+fi
+
+yes | "$SDKMANAGER" --licenses > /dev/null || true
+"$SDKMANAGER" --install \
+  "platform-tools" \
+  "platforms;android-36" \
+  "build-tools;36.0.0"
+
+echo "Android SDK ready at $ANDROID_HOME"


### PR DESCRIPTION
Adds `.devcontainer/` so the repo can run in the NAS dev-container launcher (and any devcontainer-compatible tool).

- JDK 17 base image (AGP 9.2.1 / Gradle 9.6.1 compatible)
- `post-create.sh` installs Android cmdline-tools, platform 36, build-tools 36 into a named volume (idempotent across rebuilds)
- Gradle cache on a named volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)