### PR TITLE
Add Claude Code Remote Control support to the dev container

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,52 @@
+# Dev container
+
+Runs an Android SDK toolchain and Claude Code in an isolated container.
+
+## What's included
+
+- **Java 17** base image, with the Android cmdline-tools and the platform /
+  build-tools this project targets installed by `post-create.sh` into
+  `$ANDROID_HOME` (persisted in a named volume across rebuilds).
+- **Gradle cache** persisted in a named volume across rebuilds.
+- **Claude Code** (`claude` in the terminal), with `~/.claude` persisted across
+  rebuilds in a named volume.
+
+## First run
+
+1. Open the repo in VS Code and run **Dev Containers: Reopen in Container**.
+2. Build the project: `./gradlew build`.
+
+## Controlling Claude from your phone
+
+Use [Remote Control](https://code.claude.com/docs/en/remote-control). Claude
+keeps running **inside this container** (your filesystem and Android SDK stay
+available), while claude.ai/code and the Claude mobile app act as a window
+into that local session. This is different from Claude Code on the web, which
+runs in Anthropic's cloud sandbox and can't see your container.
+
+Start (or re-attach to) the session:
+
+```bash
+.devcontainer/claude-remote.sh
+```
+
+This launches `claude --remote-control "mixtapehaven-android" --dangerously-skip-permissions`
+in a tmux session named `claude` (tmux just keeps it alive). Then:
+
+1. **Sign in once** — on first attach run `/login` and choose the claude.ai
+   option. Remote Control needs claude.ai OAuth, **not** an API key or
+   `setup-token`. Auth persists in the `~/.claude` volume across rebuilds.
+2. **Open it on your phone** — the session shows up at
+   [claude.ai/code](https://claude.ai/code) and in the Claude app (tap **Code**)
+   with a computer icon + green dot. Or scan the QR code shown in the terminal to
+   jump straight there.
+
+Requirements: a Pro / Max / Team / Enterprise plan and Claude Code v2.1.51+
+(the container ships a newer version). On Team/Enterprise an admin must enable
+the Remote Control toggle in Claude Code admin settings.
+
+> **Heads-up:** `--dangerously-skip-permissions` lets Claude run any tool
+> without asking. With Remote Control you can instead approve each tool call
+> from your phone — drop that flag in `claude-remote.sh` if you prefer to
+> review actions. It is gated on the non-root `vscode` user. Use only on
+> trusted repos.

--- a/.devcontainer/claude-remote.sh
+++ b/.devcontainer/claude-remote.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run Claude Code inside the dev container as a Remote Control session, kept
+# alive in tmux. Remote Control makes this local (in-container) session show up
+# in claude.ai/code and the Claude mobile app, so you can drive it from your
+# phone or any browser while Claude keeps running here against your local
+# filesystem and Android SDK.
+#
+#   claude-remote.sh          ensure the session exists, then attach to it
+#   claude-remote.sh start    ensure the session exists (detached); don't attach
+#
+# The `start` form is used by postAttachCommand in devcontainer.json, which has
+# no interactive terminal — so it only creates the background session.
+#
+# Connect from your phone:
+#   1. Attach locally once (`claude-remote.sh`) and run `/login` to sign in with
+#      your claude.ai account — Remote Control needs claude.ai OAuth, not an API
+#      key or setup-token. (~/.claude is a persistent volume, so this is one-time.)
+#   2. The session appears at claude.ai/code with a computer icon + green dot,
+#      or scan the QR code shown in the terminal to open it in the Claude app.
+#
+# Requirements: Pro/Max/Team/Enterprise plan; Claude Code v2.1.51+.
+#
+# WARNING: --dangerously-skip-permissions lets Claude run any tool without
+# asking. With Remote Control you can instead approve each tool call from your
+# phone — drop that flag in this script if you prefer to review actions. It is
+# gated here on the non-root `vscode` user. Use only on trusted repos.
+set -euo pipefail
+
+SESSION="claude"
+WORKSPACE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Create the session detached if it isn't already running.
+if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+	# `|| bash` keeps the tmux window open if Claude exits or fails to start,
+	# so the error stays readable for troubleshooting.
+	tmux new-session -d -s "$SESSION" \
+		"cd '$WORKSPACE_DIR' && (claude --remote-control \"mixtapehaven-android\" --dangerously-skip-permissions || bash)"
+fi
+
+# `start` just guarantees the session exists; anything else means "attach".
+if [ "${1:-}" = "start" ]; then
+	echo "Claude Remote Control session '$SESSION' is running. Attach with: tmux attach -t $SESSION"
+	exit 0
+fi
+
+exec tmux attach -t "$SESSION"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
   },
   "postCreateCommand": "bash .devcontainer/post-create.sh",
-  "postAttachCommand": ".devcontainer/claude-remote.sh start",
+  "postAttachCommand": "bash .devcontainer/claude-remote.sh start",
   "mounts": [
     "source=gradle-cache,target=/home/vscode/.gradle,type=volume",
     "source=android-sdk,target=/home/vscode/android-sdk,type=volume",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,10 +8,15 @@
   "remoteEnv": {
     "PATH": "${containerEnv:PATH}:/home/vscode/android-sdk/cmdline-tools/latest/bin:/home/vscode/android-sdk/platform-tools"
   },
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+  },
   "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "postAttachCommand": ".devcontainer/claude-remote.sh start",
   "mounts": [
     "source=gradle-cache,target=/home/vscode/.gradle,type=volume",
-    "source=android-sdk,target=/home/vscode/android-sdk,type=volume"
+    "source=android-sdk,target=/home/vscode/android-sdk,type=volume",
+    "source=mixtapehaven-claude-config-${devcontainerId},target=/home/vscode/.claude,type=volume"
   ],
   "remoteUser": "vscode",
   "customizations": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,7 +8,10 @@ ANDROID_HOME="${ANDROID_HOME:-$HOME/android-sdk}"
 CMDLINE_TOOLS_VERSION="11076708"  # "latest" as of 2024-01; pinned for reproducibility
 SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
 
-sudo apt-get update && sudo apt-get install -y tmux
+if ! command -v tmux &> /dev/null; then
+  sudo apt-get update && sudo apt-get install -y tmux
+fi
+mkdir -p "$HOME/.claude"
 sudo chown -R "$(id -u):$(id -g)" "$HOME/.claude"
 
 mkdir -p "$ANDROID_HOME"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,6 +8,9 @@ ANDROID_HOME="${ANDROID_HOME:-$HOME/android-sdk}"
 CMDLINE_TOOLS_VERSION="11076708"  # "latest" as of 2024-01; pinned for reproducibility
 SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
 
+sudo apt-get update && sudo apt-get install -y tmux
+sudo chown -R "$(id -u):$(id -g)" "$HOME/.claude"
+
 mkdir -p "$ANDROID_HOME"
 sudo chown -R "$(id -u):$(id -g)" "$ANDROID_HOME"
 


### PR DESCRIPTION
Mirrors the setup already in gaide: installs the claude-code devcontainer
feature, persists ~/.claude in a named volume, and adds a tmux-backed
claude-remote.sh so Claude can be driven from claude.ai/code or the
mobile app while running against the container's own filesystem and
Android SDK.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XFEPj7rN1JmkRqAoJVcaAb