### PR TITLE
fix: surface Random Walk failures instead of failing silently

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/diagnostics/DiagnosticsLog.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/diagnostics/DiagnosticsLog.kt
@@ -1,0 +1,40 @@
+package pe.net.libre.mixtapehaven.data.diagnostics
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * App-scoped, in-memory ring buffer of recent diagnostic events. Lets a user export a
+ * recent-activity log from Settings so failures that are otherwise silent — e.g. a swallowed
+ * Random Walk error, or a queue that resolves nothing playable — can be reported without a USB
+ * cable or `adb`. Bounded so it never grows without limit; cleared when the process dies.
+ */
+class DiagnosticsLog(private val capacity: Int = DEFAULT_CAPACITY) {
+
+    private data class Entry(val timestampMs: Long, val tag: String, val message: String)
+
+    // Oldest first; capped at [capacity]. Guarded by [lock] as events arrive from multiple threads
+    // (UI coroutines, the media3 controller callback, refill jobs).
+    private val entries = ArrayDeque<Entry>()
+    private val lock = Any()
+
+    /** Record a timestamped [message] under [tag]. Thread-safe; the oldest entry drops past capacity. */
+    fun log(tag: String, message: String) {
+        synchronized(lock) {
+            entries.addLast(Entry(System.currentTimeMillis(), tag, message))
+            while (entries.size > capacity) entries.removeFirst()
+        }
+    }
+
+    /** A newest-last, plain-text snapshot of the buffer, one entry per line, suitable for sharing. */
+    fun snapshot(): String = synchronized(lock) {
+        if (entries.isEmpty()) return "No diagnostic events recorded yet."
+        val format = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+        entries.joinToString("\n") { "${format.format(Date(it.timestampMs))}  [${it.tag}]  ${it.message}" }
+    }
+
+    private companion object {
+        const val DEFAULT_CAPACITY = 200
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.data.diagnostics.DiagnosticsLog
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
 import pe.net.libre.mixtapehaven.model.Track
 
@@ -31,6 +32,7 @@ import pe.net.libre.mixtapehaven.model.Track
 class PlayerController(
     context: Context,
     private val repository: JellyfinRepository,
+    private val diagnostics: DiagnosticsLog,
 ) {
     private val appContext = context.applicationContext
     private val scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
@@ -121,7 +123,12 @@ class PlayerController(
             refillJob?.cancel()
             refilling = false
             val items = buildItems(queue)
-            if (items.isEmpty()) return@action
+            if (items.isEmpty()) {
+                // Every track lacked an id or a resolvable stream URL (e.g. expired auth token):
+                // playback would silently do nothing, so leave a breadcrumb for Share diagnostics.
+                diagnostics.log(TAG, "play() aborted: 0 of ${queue.size} tracks resolved to a playable stream URL")
+                return@action
+            }
             c.setMediaItems(items, startIndex.coerceIn(0, items.lastIndex), 0L)
             c.prepare()
             c.play()
@@ -192,6 +199,7 @@ class PlayerController(
                     .onFailure {
                         if (it is CancellationException) throw it
                         Log.w(TAG, "Queue refill failed", it)
+                        diagnostics.log(TAG, "Queue refill failed: ${it.javaClass.simpleName}: ${it.message}")
                     }
                     .getOrDefault(emptyList())
                 if (items.isNotEmpty()) activeController()?.addMediaItems(items)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/RandomWalk.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/RandomWalk.kt
@@ -16,13 +16,14 @@ class RandomWalk(
     // Ids handed out recently, oldest first; capped at RECENT_WINDOW to avoid starving small libraries.
     private val recentIds = ArrayDeque<String>()
 
-    /** Seed the queue and arm the refill hook. No-op if the library has no tracks. */
-    suspend fun start() {
+    /** Seed the queue and arm the refill hook. Returns false without side effects if the library has no tracks. */
+    suspend fun start(): Boolean {
         val initial = nextBatch()
-        if (initial.isEmpty()) return
+        if (initial.isEmpty()) return false
         playerController.setSource(PlaybackSource.RANDOM_WALK)
         playerController.play(initial, startIndex = 0)
         playerController.onQueueRunningLow = { nextBatch() }
+        return true
     }
 
     /**

--- a/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
@@ -8,6 +8,7 @@ import pe.net.libre.mixtapehaven.data.download.DownloadDatabase
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.download.DownloadSettingsStore
 import pe.net.libre.mixtapehaven.data.download.resolveLocalFirst
+import pe.net.libre.mixtapehaven.data.diagnostics.DiagnosticsLog
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
 import pe.net.libre.mixtapehaven.data.playback.PlayerController
 import pe.net.libre.mixtapehaven.data.session.SessionStore
@@ -24,13 +25,16 @@ class AppContainer(context: Context) {
 
     val sessionStore: SessionStore = SessionStore(appContext)
 
+    /** Ring buffer of recent diagnostic events, exportable from Settings > Share diagnostics. */
+    val diagnosticsLog: DiagnosticsLog = DiagnosticsLog()
+
     val repository: JellyfinRepository = JellyfinRepository(jellyfin, sessionStore)
 
     val downloadSettingsStore: DownloadSettingsStore = DownloadSettingsStore(appContext)
 
     private val downloadDatabase: DownloadDatabase by lazy { DownloadDatabase.build(appContext) }
 
-    val playerController: PlayerController by lazy { PlayerController(appContext, repository) }
+    val playerController: PlayerController by lazy { PlayerController(appContext, repository, diagnosticsLog) }
 
     val downloadManager: DownloadManager by lazy {
         DownloadManager(

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -62,7 +62,9 @@ fun HomeScreen(
     onOpenNowPlaying: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val viewModel = appViewModel { HomeViewModel(it.repository, it.playerController, it.downloadManager, it.diagnosticsLog) }
+    val viewModel = appViewModel {
+        HomeViewModel(it.repository, it.playerController, it.downloadManager, it.diagnosticsLog)
+    }
     val state by viewModel.state.collectAsState()
     val hasDownloads = state.onDevice.isNotEmpty()
     val snackbarHostState = remember { SnackbarHostState() }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -22,10 +23,14 @@ import androidx.compose.material.icons.outlined.CloudQueue
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -57,67 +62,81 @@ fun HomeScreen(
     onOpenNowPlaying: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val viewModel = appViewModel { HomeViewModel(it.repository, it.playerController, it.downloadManager) }
+    val viewModel = appViewModel { HomeViewModel(it.repository, it.playerController, it.downloadManager, it.diagnosticsLog) }
     val state by viewModel.state.collectAsState()
     val hasDownloads = state.onDevice.isNotEmpty()
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .verticalScroll(rememberScrollState())
-            .statusBarsPadding()
-            .navigationBarsPadding()
-            .padding(horizontal = 20.dp)
-            .padding(bottom = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(20.dp),
-    ) {
-        Spacer(Modifier.size(0.dp))
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(viewModel) {
+        viewModel.snackbarMessages.collect { message -> snackbarHostState.showSnackbar(message) }
+    }
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Spacer(Modifier.size(0.dp))
 
-        HomeHeader(
-            userName = state.userName,
-            hasDownloads = hasDownloads,
-            onOpenSettings = onOpenSettings,
-        )
+            HomeHeader(
+                userName = state.userName,
+                hasDownloads = hasDownloads,
+                onOpenSettings = onOpenSettings,
+            )
 
-        RandomWalkCard(
-            onPlay = {
-                viewModel.startRandomWalk()
-                onOpenNowPlaying()
-            },
-        )
-
-        SearchField(
-            placeholder = "Search songs, albums, artists",
-            onClick = onOpenSearch,
-        )
-
-        if (hasDownloads) {
-            OnDeviceSection(
-                tracks = state.onDevice,
-                onManage = onOpenDownloads,
-                onPlay = { track ->
-                    viewModel.playOnDevice(track)
+            RandomWalkCard(
+                onPlay = {
+                    viewModel.startRandomWalk()
                     onOpenNowPlaying()
                 },
             )
-        }
 
-        SectionHeader(
-            title = "Recently added",
-            actionLabel = "See all",
-            onAction = onOpenDownloads,
-        )
-
-        if (state.albums.isEmpty()) {
-            FirstRunEmptyState(onOpenSettings = onOpenSettings)
-        } else {
-            AlbumGrid(
-                albums = state.albums,
-                onAlbumClick = { album ->
-                    viewModel.playAlbum(album)
-                    onOpenNowPlaying()
-                },
+            SearchField(
+                placeholder = "Search songs, albums, artists",
+                onClick = onOpenSearch,
             )
+
+            if (hasDownloads) {
+                OnDeviceSection(
+                    tracks = state.onDevice,
+                    onManage = onOpenDownloads,
+                    onPlay = { track ->
+                        viewModel.playOnDevice(track)
+                        onOpenNowPlaying()
+                    },
+                )
+            }
+
+            SectionHeader(
+                title = "Recently added",
+                actionLabel = "See all",
+                onAction = onOpenDownloads,
+            )
+
+            if (state.albums.isEmpty()) {
+                FirstRunEmptyState(onOpenSettings = onOpenSettings)
+            } else {
+                AlbumGrid(
+                    albums = state.albums,
+                    onAlbumClick = { album ->
+                        viewModel.playAlbum(album)
+                        onOpenNowPlaying()
+                    },
+                )
+            }
         }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
+                .padding(16.dp),
+        )
     }
 }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -1,15 +1,20 @@
 package pe.net.libre.mixtapehaven.ui.screens.home
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import pe.net.libre.mixtapehaven.data.diagnostics.DiagnosticsLog
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.download.toTrack
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
@@ -23,6 +28,7 @@ class HomeViewModel(
     private val repository: JellyfinRepository,
     private val playerController: PlayerController,
     private val downloadManager: DownloadManager,
+    private val diagnostics: DiagnosticsLog,
 ) : ViewModel() {
 
     data class UiState(
@@ -35,6 +41,11 @@ class HomeViewModel(
 
     private val _state = MutableStateFlow(UiState())
     val state: StateFlow<UiState> = _state.asStateFlow()
+
+    private val _snackbarMessages = Channel<String>(Channel.BUFFERED)
+
+    /** One-shot messages for transient UI feedback (e.g. a Snackbar), not persisted in [state]. */
+    val snackbarMessages: Flow<String> = _snackbarMessages.receiveAsFlow()
 
     init {
         load()
@@ -89,8 +100,22 @@ class HomeViewModel(
 
     /** Start an endless shuffled queue across the whole library. */
     fun startRandomWalk() {
+        diagnostics.log(TAG, "Random Walk requested")
         viewModelScope.launch {
             runCatching { RandomWalk(repository, playerController).start() }
+                .onSuccess { started ->
+                    if (started) {
+                        diagnostics.log(TAG, "Random Walk started")
+                    } else {
+                        diagnostics.log(TAG, "Random Walk produced no tracks (empty library or all filtered out)")
+                        _snackbarMessages.send("Your library has no tracks to shuffle")
+                    }
+                }
+                .onFailure { error ->
+                    Log.w(TAG, "Random Walk failed to start", error)
+                    diagnostics.log(TAG, "Random Walk failed: ${error.javaClass.simpleName}: ${error.message}")
+                    _snackbarMessages.send("Couldn't start Random Walk: ${error.message ?: "unknown error"}")
+                }
         }
     }
 
@@ -99,5 +124,9 @@ class HomeViewModel(
         val tracks = _state.value.onDevice
         val startIndex = tracks.indexOfFirst { it.id == track.id }.coerceAtLeast(0)
         if (tracks.isNotEmpty()) playerController.play(tracks, startIndex)
+    }
+
+    private companion object {
+        const val TAG = "HomeViewModel"
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package pe.net.libre.mixtapehaven.ui.screens.home
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -112,6 +113,9 @@ class HomeViewModel(
                     }
                 }
                 .onFailure { error ->
+                    // Cancellation (scope cleared / navigated away) is not a failure: let it propagate
+                    // so we don't log it or surface a spurious snackbar.
+                    if (error is CancellationException) throw error
                     Log.w(TAG, "Random Walk failed to start", error)
                     diagnostics.log(TAG, "Random Walk failed: ${error.javaClass.simpleName}: ${error.message}")
                     _snackbarMessages.send("Couldn't start Random Walk: ${error.message ?: "unknown error"}")

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsScreen.kt
@@ -1,6 +1,9 @@
 package pe.net.libre.mixtapehaven.ui.screens.settings
 
+import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -35,7 +38,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import pe.net.libre.mixtapehaven.di.appContainer
 import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.model.SampleData
 import pe.net.libre.mixtapehaven.ui.components.BackTopBar
@@ -58,13 +60,14 @@ fun SettingsScreen(
     onSignOut: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val viewModel = appViewModel { SettingsViewModel(it.downloadSettingsStore, it.downloadManager) }
+    val viewModel = appViewModel {
+        SettingsViewModel(it.downloadSettingsStore, it.downloadManager, it.diagnosticsLog)
+    }
     val automaticDownloads by viewModel.autoDownloadEnabled.collectAsState()
     val storageUsed by viewModel.storageUsedLabel.collectAsState()
     var wifiOnly by remember { mutableStateOf(true) }
 
     val context = LocalContext.current
-    val diagnosticsLog = appContainer().diagnosticsLog
 
     Column(
         modifier = modifier
@@ -166,7 +169,7 @@ fun SettingsScreen(
                 SettingLinkRow(
                     title = "Share diagnostics",
                     value = "Export",
-                    onClick = { shareDiagnostics(context, diagnosticsLog.snapshot()) },
+                    onClick = { shareDiagnostics(context, viewModel.diagnosticsSnapshot()) },
                 )
             }
         }
@@ -182,13 +185,18 @@ fun SettingsScreen(
 }
 
 /** Fire a share sheet with the recent diagnostic [log] as plain text, for bug reports. */
-private fun shareDiagnostics(context: android.content.Context, log: String) {
+private fun shareDiagnostics(context: Context, log: String) {
     val intent = Intent(Intent.ACTION_SEND).apply {
         type = "text/plain"
         putExtra(Intent.EXTRA_SUBJECT, "Mixtape Haven diagnostics")
         putExtra(Intent.EXTRA_TEXT, log)
     }
-    context.startActivity(Intent.createChooser(intent, "Share diagnostics"))
+    // No share target exists on some devices/restricted profiles; fall back to a toast, don't crash.
+    try {
+        context.startActivity(Intent.createChooser(intent, "Share diagnostics"))
+    } catch (_: ActivityNotFoundException) {
+        Toast.makeText(context, "No app available to share diagnostics", Toast.LENGTH_SHORT).show()
+    }
 }
 
 @Composable

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package pe.net.libre.mixtapehaven.ui.screens.settings
 
+import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -31,8 +32,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import pe.net.libre.mixtapehaven.di.appContainer
 import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.model.SampleData
 import pe.net.libre.mixtapehaven.ui.components.BackTopBar
@@ -59,6 +62,9 @@ fun SettingsScreen(
     val automaticDownloads by viewModel.autoDownloadEnabled.collectAsState()
     val storageUsed by viewModel.storageUsedLabel.collectAsState()
     var wifiOnly by remember { mutableStateOf(true) }
+
+    val context = LocalContext.current
+    val diagnosticsLog = appContainer().diagnosticsLog
 
     Column(
         modifier = modifier
@@ -153,6 +159,18 @@ fun SettingsScreen(
             }
         }
 
+        // Diagnostics section
+        SectionLabel("DIAGNOSTICS")
+        SurfaceCard {
+            Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+                SettingLinkRow(
+                    title = "Share diagnostics",
+                    value = "Export",
+                    onClick = { shareDiagnostics(context, diagnosticsLog.snapshot()) },
+                )
+            }
+        }
+
         Text(
             "Mixtape 1.0",
             modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
@@ -161,6 +179,16 @@ fun SettingsScreen(
             textAlign = TextAlign.Center,
         )
     }
+}
+
+/** Fire a share sheet with the recent diagnostic [log] as plain text, for bug reports. */
+private fun shareDiagnostics(context: android.content.Context, log: String) {
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_SUBJECT, "Mixtape Haven diagnostics")
+        putExtra(Intent.EXTRA_TEXT, log)
+    }
+    context.startActivity(Intent.createChooser(intent, "Share diagnostics"))
 }
 
 @Composable

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.data.diagnostics.DiagnosticsLog
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.download.DownloadSettingsStore
 import pe.net.libre.mixtapehaven.data.download.formatBytes
@@ -15,6 +16,7 @@ import pe.net.libre.mixtapehaven.data.download.formatBytes
 class SettingsViewModel(
     private val settingsStore: DownloadSettingsStore,
     downloadManager: DownloadManager,
+    private val diagnostics: DiagnosticsLog,
 ) : ViewModel() {
 
     val autoDownloadEnabled: StateFlow<Boolean> =
@@ -29,6 +31,9 @@ class SettingsViewModel(
     fun setAutoDownloadEnabled(enabled: Boolean) {
         viewModelScope.launch { settingsStore.setAutoDownloadEnabled(enabled) }
     }
+
+    /** A plain-text snapshot of the recent diagnostic events, for the Share diagnostics export. */
+    fun diagnosticsSnapshot(): String = diagnostics.snapshot()
 
     private companion object {
         const val STOP_TIMEOUT_MS = 5_000L


### PR DESCRIPTION
The Random Walk play button was a silent no-op on failure. startRandomWalk() wrapped RandomWalk.start() in runCatching {} and discarded the result, and both RandomWalk.start() and PlayerController.play() returned early on an empty batch/queue with no feedback. A user tapping play saw nothing happen and had no way to know why (empty library, lost session, or unresolvable stream URLs).

- RandomWalk.start() now returns Boolean so callers can tell "no tracks" apart from success.
- HomeViewModel surfaces both outcomes via a one-shot snackbar event Channel, with the real cause in the message, and logs to logcat.
- HomeScreen renders a SnackbarHost and collects the events.
- Add DiagnosticsLog: an app-scoped bounded in-memory ring buffer wired into the previously-silent paths (Random Walk empty/exception, PlayerController play() resolving nothing playable, and queue-refill failures).
- Settings gains a "Share diagnostics" export so users can send the recent-event log for remote debugging without adb.

Build + unit tests pass.


Claude-Session: https://claude.ai/code/session_01HQ4DNdRoEqN9bL2EGhYxpt