### PR TITLE
fix: play downloaded tracks offline and show offline state on Home

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlaybackService.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlaybackService.kt
@@ -3,6 +3,7 @@ package pe.net.libre.mixtapehaven.data.playback
 import android.content.Intent
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
@@ -19,8 +20,11 @@ class PlaybackService : MediaSessionService() {
     override fun onCreate() {
         super.onCreate()
         val httpFactory = OkHttpDataSource.Factory(OkHttpClient())
+        // Route file:// URIs (downloaded tracks) to a local FileDataSource and only
+        // http(s) through OkHttp; OkHttp alone rejects non-http schemes.
+        val dataSourceFactory = DefaultDataSource.Factory(this, httpFactory)
         val player = ExoPlayer.Builder(this)
-            .setMediaSourceFactory(DefaultMediaSourceFactory(httpFactory))
+            .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
             .setHandleAudioBecomingNoisy(true)
             .build()
         mediaSession = MediaSession.Builder(this, player).build()

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -19,7 +19,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CloudOff
 import androidx.compose.material.icons.outlined.CloudQueue
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -119,16 +121,18 @@ fun HomeScreen(
                 onAction = onOpenDownloads,
             )
 
-            if (state.albums.isEmpty()) {
-                FirstRunEmptyState(onOpenSettings = onOpenSettings)
-            } else {
-                AlbumGrid(
+            when {
+                state.albums.isNotEmpty() -> AlbumGrid(
                     albums = state.albums,
                     onAlbumClick = { album ->
                         viewModel.playAlbum(album)
                         onOpenNowPlaying()
                     },
                 )
+                // Fetch in flight: render nothing rather than flash an empty state.
+                state.loading -> Unit
+                state.error != null -> OfflineAlbumsState(onRetry = viewModel::load)
+                else -> FirstRunEmptyState(onOpenSettings = onOpenSettings)
             }
         }
 
@@ -231,6 +235,72 @@ private fun AlbumGrid(
                 if (rowAlbums.size == 1) {
                     Spacer(Modifier.weight(1f))
                 }
+            }
+        }
+    }
+}
+
+/** Shown under "Recently added" when the album fetch failed (e.g. offline): the library isn't
+ * empty, we just can't reach the server, so the copy must not claim "nothing's here yet". */
+@Composable
+private fun OfflineAlbumsState(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SurfaceCard(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(CircleShape)
+                    .background(Surface2),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Outlined.CloudOff,
+                    contentDescription = null,
+                    tint = TextMuted,
+                    modifier = Modifier.size(28.dp),
+                )
+            }
+            Text(
+                "You're offline",
+                style = MaterialTheme.typography.titleMedium,
+                color = TextPrimary,
+            )
+            Text(
+                "Recently added albums will show up when you're back online.",
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
+                textAlign = TextAlign.Center,
+            )
+            Row(
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .background(Surface2)
+                    .border(1.dp, Stroke, CircleShape)
+                    .clickable(onClick = onRetry)
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    Icons.Outlined.Refresh,
+                    contentDescription = null,
+                    tint = TextSecondary,
+                    modifier = Modifier.size(16.dp),
+                )
+                Text(
+                    "Try again",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextPrimary,
+                )
             }
         }
     }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -37,8 +38,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import pe.net.libre.mixtapehaven.R
 import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.model.Album
 import pe.net.libre.mixtapehaven.model.Track
@@ -270,39 +275,58 @@ private fun OfflineAlbumsState(
                 )
             }
             Text(
-                "You're offline",
+                stringResource(R.string.home_offline_title),
                 style = MaterialTheme.typography.titleMedium,
                 color = TextPrimary,
             )
             Text(
-                "Recently added albums will show up when you're back online.",
+                stringResource(R.string.home_offline_body),
                 style = MaterialTheme.typography.bodySmall,
                 color = TextSecondary,
                 textAlign = TextAlign.Center,
             )
-            Row(
-                modifier = Modifier
-                    .clip(CircleShape)
-                    .background(Surface2)
-                    .border(1.dp, Stroke, CircleShape)
-                    .clickable(onClick = onRetry)
-                    .padding(horizontal = 16.dp, vertical = 10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Icon(
-                    Icons.Outlined.Refresh,
-                    contentDescription = null,
-                    tint = TextSecondary,
-                    modifier = Modifier.size(16.dp),
-                )
-                Text(
-                    "Try again",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = TextPrimary,
-                )
-            }
+            PillButton(
+                icon = Icons.Outlined.Refresh,
+                label = stringResource(R.string.home_offline_retry),
+                onClick = onRetry,
+            )
         }
+    }
+}
+
+/**
+ * Small pill-shaped action button. The outer clip + clickable wrap the 48.dp minimum interactive
+ * area (for touch-target accessibility) while the background/border keep the compact pill visual.
+ */
+@Composable
+private fun PillButton(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .clip(CircleShape)
+            .clickable(role = Role.Button, onClick = onClick)
+            .minimumInteractiveComponentSize()
+            .background(Surface2, CircleShape)
+            .border(1.dp, Stroke, CircleShape)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = TextSecondary,
+            modifier = Modifier.size(16.dp),
+        )
+        Text(
+            label,
+            style = MaterialTheme.typography.bodySmall,
+            color = TextPrimary,
+        )
     }
 }
 
@@ -344,28 +368,11 @@ private fun FirstRunEmptyState(
                 color = TextSecondary,
                 textAlign = TextAlign.Center,
             )
-            Row(
-                modifier = Modifier
-                    .clip(CircleShape)
-                    .background(Surface2)
-                    .border(1.dp, Stroke, CircleShape)
-                    .clickable(onClick = onOpenSettings)
-                    .padding(horizontal = 16.dp, vertical = 10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Icon(
-                    Icons.Outlined.Settings,
-                    contentDescription = null,
-                    tint = TextSecondary,
-                    modifier = Modifier.size(16.dp),
-                )
-                Text(
-                    "Auto-download settings",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = TextPrimary,
-                )
-            }
+            PillButton(
+                icon = Icons.Outlined.Settings,
+                label = "Auto-download settings",
+                onClick = onOpenSettings,
+            )
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">Mixtape</string>
+    <string name="home_offline_title">You\'re offline</string>
+    <string name="home_offline_body">Recently added albums will show up when you\'re back online.</string>
+    <string name="home_offline_retry">Try again</string>
 </resources>


### PR DESCRIPTION
## Summary

Two fixes for the offline experience, found while debugging "downloaded files don't play when offline" on a real device:

- **Offline playback never worked.** `PlaybackService` built ExoPlayer with `DefaultMediaSourceFactory(OkHttpDataSource.Factory(...))`, forcing every media URI through OkHttp. Downloaded tracks resolve to `file://` URIs (via `DownloadManager.localUriFor`), which OkHttp rejects — so saved files could never be opened. The OkHttp factory is now wrapped in `DefaultDataSource.Factory`, which routes `file://` to a local `FileDataSource` and keeps `http(s)` on OkHttp.
- **Misleading empty state under "Recently added".** When offline, the album fetch fails and the section showed the first-run "Saves as you listen / Nothing's here yet" card — contradicting the saved songs listed right above it. Home now distinguishes the three cases: fetch failed → "You're offline" card with a *Try again* action; fetch in flight → nothing (no empty-state flash); fetch succeeded with no albums → the original first-run card.

## Testing

- `./gradlew assembleDebug` and `./gradlew test` pass.
- Verified on a Pixel 8 with no network: a track saved under "On your device" plays from local storage (player buffered ~64 s ahead while fully offline, no playback error), and the "Recently added" section shows the new offline card instead of the first-run copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)