### PR TITLE
feat: add Now Playing bar to Home screen

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/Components.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/Components.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -257,7 +258,8 @@ fun NowPlayingBar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                // The 48.dp minimum touch targets in the controls already add vertical bulk.
+                .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
@@ -278,31 +280,50 @@ fun NowPlayingBar(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            Box(
-                modifier = Modifier
-                    .size(32.dp)
-                    .clip(CircleShape)
-                    .background(Accent)
-                    .clickable(onClick = onPlayPause),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                    contentDescription = if (isPlaying) "Pause" else "Play",
-                    tint = AccentInk,
-                    modifier = Modifier.size(20.dp),
-                )
-            }
+            NowPlayingControls(isPlaying = isPlaying, onPlayPause = onPlayPause, onNext = onNext)
+        }
+    }
+}
+
+/** Play/pause and skip-next controls, each wrapped in a 48.dp minimum touch target. */
+@Composable
+private fun NowPlayingControls(
+    isPlaying: Boolean,
+    onPlayPause: () -> Unit,
+    onNext: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .clip(CircleShape)
+            .clickable(onClick = onPlayPause)
+            .minimumInteractiveComponentSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier.size(32.dp).clip(CircleShape).background(Accent),
+            contentAlignment = Alignment.Center,
+        ) {
             Icon(
-                Icons.Filled.SkipNext,
-                contentDescription = "Next track",
-                tint = TextSecondary,
-                modifier = Modifier
-                    .size(24.dp)
-                    .clip(CircleShape)
-                    .clickable(onClick = onNext),
+                if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                contentDescription = if (isPlaying) "Pause" else "Play",
+                tint = AccentInk,
+                modifier = Modifier.size(20.dp),
             )
         }
+    }
+    Box(
+        modifier = Modifier
+            .clip(CircleShape)
+            .clickable(onClick = onNext)
+            .minimumInteractiveComponentSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            Icons.Filled.SkipNext,
+            contentDescription = "Next track",
+            tint = TextSecondary,
+            modifier = Modifier.size(24.dp),
+        )
     }
 }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/Components.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/Components.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -19,8 +20,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.outlined.ArrowDownward
 import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material3.Icon
@@ -36,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import coil.compose.AsyncImage
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -225,6 +229,79 @@ fun TrackRow(
                     Icon(Icons.Outlined.ArrowDownward, contentDescription = "Downloaded", tint = Accent, modifier = Modifier.size(16.dp))
                 }
             }
+        }
+    }
+}
+
+/**
+ * Compact bar showing the current [track] with play/pause and skip-next controls.
+ * Tapping anywhere outside the controls invokes [onOpen] (navigates to Now Playing).
+ */
+@Composable
+fun NowPlayingBar(
+    track: Track,
+    isPlaying: Boolean,
+    onOpen: () -> Unit,
+    onPlayPause: () -> Unit,
+    onNext: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(Surface)
+            .clickable(onClick = onOpen)
+            .navigationBarsPadding(),
+    ) {
+        Box(Modifier.fillMaxWidth().height(1.dp).background(Stroke))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Artwork(track.artColor, track.imageUrl, Modifier.size(44.dp), corner = 8.dp)
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    track.title,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = TextPrimary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    track.artist,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(CircleShape)
+                    .background(Accent)
+                    .clickable(onClick = onPlayPause),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                    contentDescription = if (isPlaying) "Pause" else "Play",
+                    tint = AccentInk,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+            Icon(
+                Icons.Filled.SkipNext,
+                contentDescription = "Next track",
+                tint = TextSecondary,
+                modifier = Modifier
+                    .size(24.dp)
+                    .clip(CircleShape)
+                    .clickable(onClick = onNext),
+            )
         }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -48,6 +48,7 @@ import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.model.Album
 import pe.net.libre.mixtapehaven.model.Track
 import pe.net.libre.mixtapehaven.ui.components.AlbumCard
+import pe.net.libre.mixtapehaven.ui.components.NowPlayingBar
 import pe.net.libre.mixtapehaven.ui.components.RandomWalkCard
 import pe.net.libre.mixtapehaven.ui.components.SearchField
 import pe.net.libre.mixtapehaven.ui.components.SectionHeader
@@ -73,6 +74,8 @@ fun HomeScreen(
         HomeViewModel(it.repository, it.playerController, it.downloadManager, it.diagnosticsLog)
     }
     val state by viewModel.state.collectAsState()
+    val nowPlayingTrack by viewModel.nowPlaying.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
     val hasDownloads = state.onDevice.isNotEmpty()
     val snackbarHostState = remember { SnackbarHostState() }
     LaunchedEffect(viewModel) {
@@ -86,7 +89,8 @@ fun HomeScreen(
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .padding(horizontal = 20.dp)
-                .padding(bottom = 24.dp),
+                // Extra bottom padding keeps the last items reachable above the Now Playing bar.
+                .padding(bottom = if (nowPlayingTrack != null) 96.dp else 24.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             Spacer(Modifier.size(0.dp))
@@ -146,8 +150,20 @@ fun HomeScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .navigationBarsPadding()
-                .padding(16.dp),
+                .padding(16.dp)
+                .padding(bottom = if (nowPlayingTrack != null) 68.dp else 0.dp),
         )
+
+        nowPlayingTrack?.let { track ->
+            NowPlayingBar(
+                track = track,
+                isPlaying = isPlaying,
+                onOpen = onOpenNowPlaying,
+                onPlayPause = viewModel::playPause,
+                onNext = viewModel::playNext,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -43,6 +43,10 @@ class HomeViewModel(
     private val _state = MutableStateFlow(UiState())
     val state: StateFlow<UiState> = _state.asStateFlow()
 
+    /** Current track and playback state for the bottom Now Playing bar. */
+    val nowPlaying: StateFlow<Track?> = playerController.nowPlaying
+    val isPlaying: StateFlow<Boolean> = playerController.isPlaying
+
     private val _snackbarMessages = Channel<String>(Channel.BUFFERED)
 
     /** One-shot messages for transient UI feedback (e.g. a Snackbar), not persisted in [state]. */
@@ -122,6 +126,10 @@ class HomeViewModel(
                 }
         }
     }
+
+    fun playPause() = playerController.playPause()
+
+    fun playNext() = playerController.next()
 
     /** Play the offline library starting from [track] (serves from local files first). */
     fun playOnDevice(track: Track) {


### PR DESCRIPTION
## Summary
- Implements the "Now Playing Bar" from the Home Screen pencil design: a persistent bottom bar showing the current track''s artwork, title, and artist, with play/pause and skip-next controls.
- Tapping the bar (outside the controls) navigates to the Now Playing screen.
- The bar only appears while a track is loaded; Home content gets extra bottom padding and the snackbar shifts up so nothing is hidden behind it.

## Changes
- `Components.kt`: new reusable `NowPlayingBar` composable (surface background, 1dp top hairline, 44dp artwork with vinyl fallback, accent play/pause circle, skip-next icon).
- `HomeViewModel.kt`: exposes `nowPlaying`/`isPlaying` from `PlayerController` plus `playPause()`/`playNext()`.
- `HomeScreen.kt`: pins the bar to the bottom, wires it to navigation and playback controls.

## Testing
- `compileDebugKotlin` passes.
- Verified on a Pixel device: bar appears when Random Walk starts, tapping it opens Now Playing, play/pause toggles in place, skip-next advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)