### PR TITLE
fix: stop idle battery drain from playback polling and eager service bind

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlaybackService.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlaybackService.kt
@@ -2,6 +2,7 @@ package pe.net.libre.mixtapehaven.data.playback
 
 import android.content.Intent
 import androidx.annotation.OptIn
+import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
@@ -26,6 +27,8 @@ class PlaybackService : MediaSessionService() {
         val player = ExoPlayer.Builder(this)
             .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
             .setHandleAudioBecomingNoisy(true)
+            // Hold CPU + WiFi awake only while playing, so streaming survives screen-off/doze.
+            .setWakeMode(C.WAKE_MODE_NETWORK)
             .build()
         mediaSession = MediaSession.Builder(this, player).build()
     }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -102,10 +102,15 @@ class PlayerController(
             _isPlaying.collectLatest { playing ->
                 if (!playing) return@collectLatest
                 while (currentCoroutineContext().isActive) {
-                    activeController()?.let { c ->
-                        _durationMs.value = c.duration.coerceAtLeast(0)
-                        _positionMs.value = c.currentPosition.coerceAtLeast(0)
+                    val c = activeController()
+                    if (c == null) {
+                        // Controller lost mid-playback (service killed): stop polling and reset
+                        // the flag, else its conflated true would keep the loop from restarting.
+                        _isPlaying.value = false
+                        break
                     }
+                    _durationMs.value = c.duration.coerceAtLeast(0)
+                    _positionMs.value = c.currentPosition.coerceAtLeast(0)
                     delay(PROGRESS_INTERVAL_MS)
                 }
             }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -15,10 +15,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import pe.net.libre.mixtapehaven.data.diagnostics.DiagnosticsLog
@@ -55,6 +57,7 @@ class PlayerController(
     val source: StateFlow<PlaybackSource> = _source.asStateFlow()
 
     private var controller: MediaController? = null
+    private var connecting = false
     private var pendingAction: (() -> Unit)? = null
     private var refilling = false
     private var refillJob: Job? = null
@@ -93,15 +96,18 @@ class PlayerController(
     }
 
     init {
-        connect()
+        // Poll position/duration only while something is actually playing; while paused or idle
+        // the loop is suspended so the app does no periodic work (seeks are handled by the listener).
         scope.launch {
-            while (isActive) {
-                activeController()?.let { c ->
-                    _durationMs.value = c.duration.coerceAtLeast(0)
-                    // Position only advances while playing; seeks are handled by the listener.
-                    if (c.isPlaying) _positionMs.value = c.currentPosition.coerceAtLeast(0)
+            _isPlaying.collectLatest { playing ->
+                if (!playing) return@collectLatest
+                while (currentCoroutineContext().isActive) {
+                    activeController()?.let { c ->
+                        _durationMs.value = c.duration.coerceAtLeast(0)
+                        _positionMs.value = c.currentPosition.coerceAtLeast(0)
+                    }
+                    delay(PROGRESS_INTERVAL_MS)
                 }
-                delay(PROGRESS_INTERVAL_MS)
             }
         }
     }
@@ -137,9 +143,10 @@ class PlayerController(
         if (c != null && c.isConnected) {
             action()
         } else {
-            // The service may have been destroyed, leaving a dead controller; rebuild it.
+            // Not yet connected (first play) or the service died, leaving a dead controller.
+            // Either way, (re)build the connection and run the action once it is live.
             pendingAction = action
-            if (c != null) reconnect()
+            if (c != null) reconnect() else connect()
         }
     }
 
@@ -210,10 +217,13 @@ class PlayerController(
     }
 
     private fun connect() {
+        if (connecting) return
+        connecting = true
         val token = SessionToken(appContext, ComponentName(appContext, PlaybackService::class.java))
         val future = MediaController.Builder(appContext, token).buildAsync()
         future.addListener(
             {
+                connecting = false
                 val c = future.get()
                 controller = c
                 c.addListener(listener)


### PR DESCRIPTION
## Problem
The app drains battery while idle. Two causes in the playback layer:

1. `PlayerController`'s position/duration polling loop ran every **500ms from app launch until process death**, regardless of playback state — even paused, backgrounded, or having never played anything.
2. The `MediaController` connected in the constructor, binding `PlaybackService` (and building its ExoPlayer) at process start. A bound `MediaSessionService` can't stop itself, so the service stayed alive for the whole process lifetime.

## Fix
- The polling loop is now driven by `isPlaying.collectLatest`: it ticks only while something is actually playing and fully suspends otherwise. Seeks while paused are still reflected instantly via the existing `onPositionDiscontinuity` listener.
- The controller now connects lazily on first `play()`, reusing the existing `pendingAction` mechanism, with a `connecting` guard so rapid double-`play()` can't build and leak a second controller.
- Added `setWakeMode(C.WAKE_MODE_NETWORK)` to the ExoPlayer so streaming survives screen-off/doze; media3 holds the lock only while playing, so this adds no idle drain.

## Testing
- `:app:testDebugUnitTest` passes.
- Installed on a physical device; playback, pause/resume, and seek work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)