### PR TITLE
feat: add Up Next queue card to Now Playing screen

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -133,6 +133,7 @@ class PlayerController(
             // Drop any in-flight refill so its tracks aren't appended to this new queue.
             refillJob?.cancel()
             refilling = false
+            tracksById.clear()
             val items = buildItems(queue)
             if (items.isEmpty()) {
                 // Every track lacked an id or a resolvable stream URL (e.g. expired auth token):
@@ -257,11 +258,8 @@ class PlayerController(
 
     private fun updateQueue() {
         val c = activeController() ?: return
-        val items = (0 until c.mediaItemCount).mapNotNull { c.getMediaItemAt(it).mediaId.let(tracksById::get) }
-        val index = c.currentMediaItemIndex
-        Log.d(TAG, "updateQueue: ${items.size} items, index=$index, tracksById=${tracksById.size}")
-        _queue.value = items
-        _queueIndex.value = index
+        _queue.value = (0 until c.mediaItemCount).mapNotNull { c.getMediaItemAt(it).mediaId.let(tracksById::get) }
+        _queueIndex.value = c.currentMediaItemIndex
     }
 
     private fun buildMediaItem(track: Track, id: String, url: String): MediaItem {

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -72,6 +72,12 @@ class PlayerController(
     private val _durationMs = MutableStateFlow(0L)
     val durationMs: StateFlow<Long> = _durationMs.asStateFlow()
 
+    private val _queue = MutableStateFlow<List<Track>>(emptyList())
+    val queue: StateFlow<List<Track>> = _queue.asStateFlow()
+
+    private val _queueIndex = MutableStateFlow(-1)
+    val queueIndex: StateFlow<Int> = _queueIndex.asStateFlow()
+
     private val listener = object : Player.Listener {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             _isPlaying.value = isPlaying
@@ -79,7 +85,12 @@ class PlayerController(
 
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
             updateNowPlaying(mediaItem)
+            updateQueue()
             maybeRefillQueue()
+        }
+
+        override fun onTimelineChanged(timeline: androidx.media3.common.Timeline, reason: Int) {
+            updateQueue()
         }
 
         override fun onPositionDiscontinuity(
@@ -132,6 +143,7 @@ class PlayerController(
             c.setMediaItems(items, startIndex.coerceIn(0, items.lastIndex), 0L)
             c.prepare()
             c.play()
+            updateQueue()
         }
         val c = controller
         if (c != null && c.isConnected) {
@@ -168,6 +180,8 @@ class PlayerController(
         _isPlaying.value = false
         _positionMs.value = 0
         _durationMs.value = 0
+        _queue.value = emptyList()
+        _queueIndex.value = -1
     }
 
     /** The controller only if it is still connected to a live service, else null. */
@@ -202,7 +216,10 @@ class PlayerController(
                         diagnostics.log(TAG, "Queue refill failed: ${it.javaClass.simpleName}: ${it.message}")
                     }
                     .getOrDefault(emptyList())
-                if (items.isNotEmpty()) activeController()?.addMediaItems(items)
+                if (items.isNotEmpty()) {
+                    activeController()?.addMediaItems(items)
+                    updateQueue()
+                }
             } finally {
                 refilling = false
             }
@@ -219,6 +236,7 @@ class PlayerController(
                 c.addListener(listener)
                 _isPlaying.value = c.isPlaying
                 updateNowPlaying(c.currentMediaItem)
+                updateQueue()
                 pendingAction?.invoke()
                 pendingAction = null
             },
@@ -235,6 +253,15 @@ class PlayerController(
 
     private fun updateNowPlaying(mediaItem: MediaItem?) {
         _nowPlaying.value = mediaItem?.mediaId?.let { tracksById[it] }
+    }
+
+    private fun updateQueue() {
+        val c = activeController() ?: return
+        val items = (0 until c.mediaItemCount).mapNotNull { c.getMediaItemAt(it).mediaId.let(tracksById::get) }
+        val index = c.currentMediaItemIndex
+        Log.d(TAG, "updateQueue: ${items.size} items, index=$index, tracksById=${tracksById.size}")
+        _queue.value = items
+        _queueIndex.value = index
     }
 
     private fun buildMediaItem(track: Track, id: String, url: String): MediaItem {

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
@@ -24,6 +25,7 @@ import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material.icons.outlined.Shuffle
+import androidx.compose.material.icons.outlined.ArrowDownward
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -35,13 +37,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.ui.components.Artwork
 import pe.net.libre.mixtapehaven.ui.theme.Accent
 import pe.net.libre.mixtapehaven.ui.theme.AccentInk
 import pe.net.libre.mixtapehaven.ui.theme.Bg
+import pe.net.libre.mixtapehaven.ui.theme.Surface
 import pe.net.libre.mixtapehaven.ui.theme.Surface2
 import pe.net.libre.mixtapehaven.ui.theme.TextMuted
 import pe.net.libre.mixtapehaven.ui.theme.TextPrimary
@@ -57,6 +63,8 @@ fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
     val source by viewModel.source.collectAsState()
     val savingPercent by viewModel.savingPercent.collectAsState()
     val offlineReady by viewModel.offlineReady.collectAsState()
+    val upNext by viewModel.upNext.collectAsState()
+    val upNextOfflineReady by viewModel.upNextOfflineReady.collectAsState()
 
     val progress = if (durationMs > 0) (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
 
@@ -193,6 +201,14 @@ fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 modifier = Modifier.size(24.dp),
             )
         }
+
+        if (upNext != null) {
+            UpNextCard(
+                track = upNext!!,
+                source = source,
+                offlineReady = upNextOfflineReady,
+            )
+        }
     }
 }
 
@@ -217,6 +233,97 @@ private fun OfflineStatus(savingPercent: Int?, offlineReady: Boolean, modifier: 
 }
 
 private val OfflineReadyGreen = androidx.compose.ui.graphics.Color(0xFF7BB661)
+
+@Composable
+private fun UpNextCard(
+    track: pe.net.libre.mixtapehaven.model.Track,
+    source: pe.net.libre.mixtapehaven.data.playback.PlaybackSource,
+    offlineReady: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val headerLabel = when (source) {
+        pe.net.libre.mixtapehaven.data.playback.PlaybackSource.RANDOM_WALK -> "NEXT ON YOUR WALK"
+        else -> "UP NEXT"
+    }
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(Surface)
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Outlined.Shuffle,
+                    contentDescription = null,
+                    tint = TextMuted,
+                    modifier = Modifier.size(15.dp),
+                )
+                Text(
+                    headerLabel,
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 1.sp,
+                    ),
+                    color = TextMuted,
+                )
+            }
+            Text(
+                "Queue",
+                style = MaterialTheme.typography.bodySmall,
+                color = Accent,
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Artwork(
+                color = track.artColor,
+                imageUrl = track.imageUrl,
+                modifier = Modifier.size(42.dp),
+                corner = 8.dp,
+            )
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text(
+                    track.title,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = TextPrimary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    track.artist,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (offlineReady) {
+                Icon(
+                    Icons.Outlined.ArrowDownward,
+                    contentDescription = "Offline ready",
+                    tint = Accent,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}
 
 private fun formatTime(ms: Long): String {
     if (ms <= 0) return "0:00"

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingScreen.kt
@@ -202,9 +202,10 @@ fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
             )
         }
 
-        if (upNext != null) {
+        val nextTrack = upNext
+        if (nextTrack != null) {
             UpNextCard(
-                track = upNext!!,
+                track = nextTrack,
                 source = source,
                 offlineReady = upNextOfflineReady,
             )
@@ -241,10 +242,6 @@ private fun UpNextCard(
     offlineReady: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val headerLabel = when (source) {
-        pe.net.libre.mixtapehaven.data.playback.PlaybackSource.RANDOM_WALK -> "NEXT ON YOUR WALK"
-        else -> "UP NEXT"
-    }
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -253,74 +250,91 @@ private fun UpNextCard(
             .padding(14.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
+        UpNextHeader(source)
+        UpNextTrackRow(track, offlineReady)
+    }
+}
+
+@Composable
+private fun UpNextHeader(source: pe.net.libre.mixtapehaven.data.playback.PlaybackSource) {
+    val headerLabel = when (source) {
+        pe.net.libre.mixtapehaven.data.playback.PlaybackSource.RANDOM_WALK -> "NEXT ON YOUR WALK"
+        else -> "UP NEXT"
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    Icons.Outlined.Shuffle,
-                    contentDescription = null,
-                    tint = TextMuted,
-                    modifier = Modifier.size(15.dp),
-                )
-                Text(
-                    headerLabel,
-                    style = MaterialTheme.typography.labelSmall.copy(
-                        fontWeight = FontWeight.Bold,
-                        letterSpacing = 1.sp,
-                    ),
-                    color = TextMuted,
-                )
-            }
+            Icon(
+                Icons.Outlined.Shuffle,
+                contentDescription = null,
+                tint = TextMuted,
+                modifier = Modifier.size(15.dp),
+            )
             Text(
-                "Queue",
-                style = MaterialTheme.typography.bodySmall,
-                color = Accent,
+                headerLabel,
+                style = MaterialTheme.typography.labelSmall.copy(
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.sp,
+                ),
+                color = TextMuted,
             )
         }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        Text(
+            "Queue",
+            style = MaterialTheme.typography.bodySmall,
+            color = Accent,
+        )
+    }
+}
+
+@Composable
+private fun UpNextTrackRow(
+    track: pe.net.libre.mixtapehaven.model.Track,
+    offlineReady: Boolean,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Artwork(
+            color = track.artColor,
+            imageUrl = track.imageUrl,
+            modifier = Modifier.size(42.dp),
+            corner = 8.dp,
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
-            Artwork(
-                color = track.artColor,
-                imageUrl = track.imageUrl,
-                modifier = Modifier.size(42.dp),
-                corner = 8.dp,
+            Text(
+                track.title,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = TextPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                Text(
-                    track.title,
-                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
-                    color = TextPrimary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    track.artist,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = TextSecondary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            if (offlineReady) {
-                Icon(
-                    Icons.Outlined.ArrowDownward,
-                    contentDescription = "Offline ready",
-                    tint = Accent,
-                    modifier = Modifier.size(18.dp),
-                )
-            }
+            Text(
+                track.artist,
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (offlineReady) {
+            Icon(
+                Icons.Outlined.ArrowDownward,
+                contentDescription = "Offline ready",
+                tint = Accent,
+                modifier = Modifier.size(18.dp),
+            )
         }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.playback.PlaybackSource
@@ -21,6 +22,19 @@ class NowPlayingViewModel(
     val positionMs: StateFlow<Long> = playerController.positionMs
     val durationMs: StateFlow<Long> = playerController.durationMs
     val source: StateFlow<PlaybackSource> = playerController.source
+    val queue: StateFlow<List<Track>> = playerController.queue
+
+    val upNext: StateFlow<Track?> = combine(
+        playerController.queue,
+        playerController.queueIndex,
+    ) { queue, index ->
+        queue.getOrNull(index + 1)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), null)
+
+    val upNextOfflineReady: StateFlow<Boolean> =
+        combine(upNext, downloadManager.downloads) { track, rows ->
+            track?.id != null && rows.any { it.id == track.id && it.complete }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), false)
 
     /** Save percent (0-100) when the current track is being downloaded, else null. */
     val savingPercent: StateFlow<Int?> =

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.playback.PlaybackSource
@@ -28,7 +27,7 @@ class NowPlayingViewModel(
         playerController.queue,
         playerController.queueIndex,
     ) { queue, index ->
-        queue.getOrNull(index + 1)
+        if (index >= 0) queue.getOrNull(index + 1) else null
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), null)
 
     val upNextOfflineReady: StateFlow<Boolean> =


### PR DESCRIPTION
## Summary

Adds the **Up Next** queue card at the bottom of the Now Playing screen, matching the `happypath.pen` design.

## Changes

- **PlayerController.kt** — Exposes `queue` (list of tracks) and `queueIndex` (current position) as `StateFlow`s. Kept in sync via:
  - `onMediaItemTransition` listener
  - `onTimelineChanged` listener (catches queue additions/refills)
  - `play()`, `stop()`, `connect()`, and the refill hook
- **NowPlayingViewModel.kt** — Derives `upNext` (track after current) and `upNextOfflineReady` from the new flows.
- **NowPlayingScreen.kt** — Renders an `UpNextCard` below the controls: rounded `Surface` card with a header ("NEXT ON YOUR WALK" for Random Walk, "UP NEXT" otherwise) + "Queue" link, and the next track's artwork (42dp), title/artist, and an offline-ready indicator.

## Test plan

- [ ] Start a Random Walk from Home and open Now Playing — Up Next card appears with the next track.
- [ ] Play an album from Home — Up Next card shows the next track.
- [ ] Reach the last track of a queue — card hides (no up next).
- [ ] Verify offline-ready indicator appears only for saved tracks.

Follows #144.
