### PR TITLE
feat: stream movies & TV series from Jellyfin (video step 1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     implementation(libs.slf4j.api)
     implementation(libs.okhttp)
     implementation(libs.media3.exoplayer)
+    implementation(libs.media3.exoplayer.hls)
+    implementation(libs.media3.ui)
     implementation(libs.media3.session)
     implementation(libs.media3.datasource.okhttp)
     implementation(libs.coil.compose)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
@@ -7,20 +7,31 @@ import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.audioApi
 import org.jellyfin.sdk.api.client.extensions.authenticateUserByName
+import org.jellyfin.sdk.api.client.extensions.dynamicHlsApi
 import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.api.client.extensions.itemsApi
+import org.jellyfin.sdk.api.client.extensions.playStateApi
+import org.jellyfin.sdk.api.client.extensions.tvShowsApi
 import org.jellyfin.sdk.api.client.extensions.userApi
+import org.jellyfin.sdk.api.client.extensions.userLibraryApi
+import org.jellyfin.sdk.api.client.extensions.videosApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ImageType
+import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
+import org.jellyfin.sdk.model.api.PlayMethod
 import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.api.request.GetItemsRequest
 import pe.net.libre.mixtapehaven.data.session.Session
 import pe.net.libre.mixtapehaven.data.session.SessionStore
 import pe.net.libre.mixtapehaven.model.Album
 import pe.net.libre.mixtapehaven.model.Track
+import pe.net.libre.mixtapehaven.model.VideoItem
 import java.util.UUID
+
+/** Lifecycle moment of video playback reported to the server via [JellyfinRepository.reportVideoPlayback]. */
+enum class VideoPlaybackEvent { STARTED, PROGRESS, STOPPED }
 
 /** Wraps the Jellyfin Kotlin SDK: authentication, library browsing, search, and stream/image URLs. */
 class JellyfinRepository(
@@ -141,6 +152,104 @@ class JellyfinRepository(
         }
     }
 
+    /** Movies and TV series for the Home "Movies & shows" row, newest first. Empty if no video libraries. */
+    suspend fun moviesAndShows(limit: Int = 20): List<VideoItem> {
+        val client = requireApi()
+        val result by client.itemsApi.getItems(
+            GetItemsRequest(
+                userId = userId,
+                includeItemTypes = listOf(BaseItemKind.MOVIE, BaseItemKind.SERIES),
+                recursive = true,
+                sortBy = listOf(ItemSortBy.DATE_CREATED),
+                sortOrder = listOf(SortOrder.DESCENDING),
+                limit = limit,
+            ),
+        )
+        return result.items.orEmpty().map { it.toVideoItem(client) }
+    }
+
+    /** Full detail (overview + this user's resume position) for one movie/series/episode. */
+    suspend fun videoItem(itemId: String): VideoItem? {
+        val client = requireApi()
+        val id = runCatching { UUID.fromString(itemId) }.getOrNull() ?: return null
+        val item by client.userLibraryApi.getItem(itemId = id, userId = userId)
+        return item.toVideoItem(client)
+    }
+
+    /** All episodes of [seriesId] in season/episode order, with overviews and resume positions. */
+    suspend fun seriesEpisodes(seriesId: String): List<VideoItem> {
+        val client = requireApi()
+        val id = runCatching { UUID.fromString(seriesId) }.getOrNull() ?: return emptyList()
+        val result by client.tvShowsApi.getEpisodes(
+            seriesId = id,
+            userId = userId,
+            fields = listOf(ItemFields.OVERVIEW),
+        )
+        return result.items.orEmpty().map { it.toVideoItem(client) }
+    }
+
+    /**
+     * Ordered stream URL candidates for [itemId]: direct play of the original file first, then an
+     * HLS transcode pinned to h264/aac for anything the device cannot play natively. The player
+     * tries them in order and falls through on error.
+     */
+    fun videoStreamCandidates(itemId: String): List<String> {
+        val client = api
+        val id = runCatching { UUID.fromString(itemId) }.getOrNull()
+        if (client == null || id == null) return emptyList()
+        val direct = client.videosApi
+            .getVideoStreamUrl(itemId = id, static = true)
+            .withApiKey(client)
+        val hls = client.dynamicHlsApi
+            .getMasterHlsVideoPlaylistUrl(
+                itemId = id,
+                // The server requires a media source; the default source id is the item id unhyphenated.
+                mediaSourceId = itemId.replace("-", ""),
+                videoCodec = "h264",
+                audioCodec = "aac",
+            )
+            .withApiKey(client)
+        return listOf(direct, hls)
+    }
+
+    /**
+     * Report a video playback [event] at [positionMs] to the server. Progress feeds the
+     * server-side resume point (and Continue Watching); STOPPED finalizes it. Failures are
+     * swallowed: playstate reporting must never break playback.
+     */
+    suspend fun reportVideoPlayback(
+        itemId: String,
+        positionMs: Long,
+        event: VideoPlaybackEvent,
+        paused: Boolean = false,
+    ) {
+        val client = api
+        val id = runCatching { UUID.fromString(itemId) }.getOrNull()
+        if (client == null || id == null) return
+        runCatching {
+            when (event) {
+                VideoPlaybackEvent.STARTED -> {
+                    client.playStateApi.onPlaybackStart(itemId = id, playMethod = PlayMethod.DIRECT_STREAM)
+                    if (positionMs > 0) {
+                        reportVideoPlayback(itemId, positionMs, VideoPlaybackEvent.PROGRESS)
+                    }
+                }
+
+                VideoPlaybackEvent.PROGRESS -> client.playStateApi.onPlaybackProgress(
+                    itemId = id,
+                    positionTicks = positionMs * TICKS_PER_MS,
+                    isPaused = paused,
+                    playMethod = PlayMethod.DIRECT_STREAM,
+                )
+
+                VideoPlaybackEvent.STOPPED -> client.playStateApi.onPlaybackStopped(
+                    itemId = id,
+                    positionTicks = positionMs * TICKS_PER_MS,
+                )
+            }
+        }
+    }
+
     private fun requireApi(): ApiClient =
         api ?: error("Not authenticated with a Jellyfin server")
 
@@ -181,14 +290,7 @@ class JellyfinRepository(
         }
     }
 
-    private fun String.withApiKey(client: ApiClient): String {
-        val token = client.accessToken ?: return this
-        val separator = if (contains('?')) '&' else '?'
-        return "$this${separator}ApiKey=$token"
-    }
-
     private companion object {
-        const val IMAGE_MAX_WIDTH = 600
         const val TICKS_PER_SECOND = 10_000_000L
 
         val PALETTE = listOf(

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
@@ -222,16 +222,18 @@ class JellyfinRepository(
         positionMs: Long,
         event: VideoPlaybackEvent,
         paused: Boolean = false,
+        transcoding: Boolean = false,
     ) {
         val client = api
         val id = runCatching { UUID.fromString(itemId) }.getOrNull()
         if (client == null || id == null) return
+        val playMethod = if (transcoding) PlayMethod.TRANSCODE else PlayMethod.DIRECT_STREAM
         runCatching {
             when (event) {
                 VideoPlaybackEvent.STARTED -> {
-                    client.playStateApi.onPlaybackStart(itemId = id, playMethod = PlayMethod.DIRECT_STREAM)
+                    client.playStateApi.onPlaybackStart(itemId = id, playMethod = playMethod)
                     if (positionMs > 0) {
-                        reportVideoPlayback(itemId, positionMs, VideoPlaybackEvent.PROGRESS)
+                        reportVideoPlayback(itemId, positionMs, VideoPlaybackEvent.PROGRESS, transcoding = transcoding)
                     }
                 }
 
@@ -239,7 +241,7 @@ class JellyfinRepository(
                     itemId = id,
                     positionTicks = positionMs * TICKS_PER_MS,
                     isPaused = paused,
-                    playMethod = PlayMethod.DIRECT_STREAM,
+                    playMethod = playMethod,
                 )
 
                 VideoPlaybackEvent.STOPPED -> client.playStateApi.onPlaybackStopped(

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinVideoMapping.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinVideoMapping.kt
@@ -1,0 +1,84 @@
+package pe.net.libre.mixtapehaven.data.jellyfin
+
+import androidx.compose.ui.graphics.Color
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.imageApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.ImageType
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
+
+/** Mapping from Jellyfin DTOs to the video domain model, kept out of [JellyfinRepository] for size. */
+
+internal const val IMAGE_MAX_WIDTH = 600
+internal const val BACKDROP_MAX_WIDTH = 1280
+internal const val TICKS_PER_MS = 10_000L
+
+/** Jellyfin URLs carry no auth by default; media/image requests authenticate via this query param. */
+internal fun String.withApiKey(client: ApiClient): String {
+    val token = client.accessToken ?: return this
+    val separator = if (contains('?')) '&' else '?'
+    return "$this${separator}ApiKey=$token"
+}
+
+internal fun BaseItemDto.toVideoItem(client: ApiClient): VideoItem {
+    val runtimeMs = (runTimeTicks ?: 0L) / TICKS_PER_MS
+    return VideoItem(
+        id = id.toString(),
+        title = name ?: "Untitled",
+        kind = when (type) {
+            BaseItemKind.SERIES -> VideoKind.SERIES
+            BaseItemKind.EPISODE -> VideoKind.EPISODE
+            else -> VideoKind.MOVIE
+        },
+        yearLabel = productionYear?.toString().orEmpty(),
+        runtimeLabel = formatRuntime(runtimeMs),
+        overview = overview.orEmpty(),
+        posterUrl = videoPrimaryImageUrl(client),
+        backdropUrl = backdropImageUrl(client),
+        artColor = videoColorFor(id.toString()),
+        runtimeMs = runtimeMs,
+        resumePositionMs = (userData?.playbackPositionTicks ?: 0L) / TICKS_PER_MS,
+        seriesName = seriesName,
+        seasonEpisodeLabel = if (type == BaseItemKind.EPISODE && parentIndexNumber != null && indexNumber != null) {
+            "S$parentIndexNumber E$indexNumber"
+        } else {
+            null
+        },
+    )
+}
+
+private fun BaseItemDto.videoPrimaryImageUrl(client: ApiClient): String? {
+    val tag = imageTags?.get(ImageType.PRIMARY) ?: return null
+    return client.imageApi
+        .getItemImageUrl(id, ImageType.PRIMARY, tag = tag, maxWidth = IMAGE_MAX_WIDTH)
+        .withApiKey(client)
+}
+
+private fun BaseItemDto.backdropImageUrl(client: ApiClient): String? {
+    val tag = backdropImageTags?.firstOrNull() ?: return null
+    return client.imageApi
+        .getItemImageUrl(id, ImageType.BACKDROP, tag = tag, maxWidth = BACKDROP_MAX_WIDTH)
+        .withApiKey(client)
+}
+
+internal fun formatRuntime(runtimeMs: Long): String {
+    if (runtimeMs <= 0) return ""
+    val totalMinutes = runtimeMs / 60_000
+    val hours = totalMinutes / 60
+    val minutes = totalMinutes % 60
+    return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+}
+
+private val VIDEO_PALETTE = listOf(
+    Color(0xFFC65B4E),
+    Color(0xFF9A8A3C),
+    Color(0xFFA86B7E),
+    Color(0xFFB5633B),
+    Color(0xFFB59A4E),
+    Color(0xFF6C8A7A),
+)
+
+internal fun videoColorFor(key: String): Color =
+    VIDEO_PALETTE[(key.hashCode() and Int.MAX_VALUE) % VIDEO_PALETTE.size]

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -168,6 +168,9 @@ class PlayerController(
         }
     }
 
+    /** Pause without clearing the queue; used when another player (e.g. video) takes over audio. */
+    fun pause() = activeController()?.pause() ?: Unit
+
     fun playPause() {
         val c = activeController() ?: return
         if (c.isPlaying) c.pause() else c.play()

--- a/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
@@ -36,6 +36,13 @@ class AppContainer(context: Context) {
 
     val playerController: PlayerController by lazy { PlayerController(appContext, repository, diagnosticsLog) }
 
+    /**
+     * Resolves ordered playable source URLs for a video item id. Defaults to remote streaming
+     * (direct play, then HLS transcode); swap to serve local video downloads first, mirroring
+     * [PlayerController.streamUrlResolver] for audio.
+     */
+    var videoSourceResolver: (String) -> List<String> = repository::videoStreamCandidates
+
     val downloadManager: DownloadManager by lazy {
         DownloadManager(
             context = appContext,

--- a/app/src/main/java/pe/net/libre/mixtapehaven/model/VideoItem.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/model/VideoItem.kt
@@ -6,9 +6,11 @@ import androidx.compose.ui.graphics.Color
 enum class VideoKind { MOVIE, SERIES, EPISODE }
 
 /**
- * A video library item (movie, TV series, or episode). [posterUrl] is the portrait primary image
- * ([backdropUrl] the wide art); [artColor] is the tint fallback when no artwork exists.
- * [resumePositionMs] > 0 means the server has an in-progress watch position for this user.
+ * A video library item (movie, TV series, or episode). [posterUrl] is the PRIMARY image — a
+ * portrait 2:3 poster for movies/series, but a 16:9 still for episodes (that is what Jellyfin
+ * stores as an episode's primary). [backdropUrl] is the wide art; [artColor] is the tint fallback
+ * when no artwork exists. [resumePositionMs] > 0 means the server has an in-progress watch
+ * position for this user.
  */
 data class VideoItem(
     val id: String,

--- a/app/src/main/java/pe/net/libre/mixtapehaven/model/VideoItem.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/model/VideoItem.kt
@@ -1,0 +1,27 @@
+package pe.net.libre.mixtapehaven.model
+
+import androidx.compose.ui.graphics.Color
+
+/** What a [VideoItem] represents in the library hierarchy. */
+enum class VideoKind { MOVIE, SERIES, EPISODE }
+
+/**
+ * A video library item (movie, TV series, or episode). [posterUrl] is the portrait primary image
+ * ([backdropUrl] the wide art); [artColor] is the tint fallback when no artwork exists.
+ * [resumePositionMs] > 0 means the server has an in-progress watch position for this user.
+ */
+data class VideoItem(
+    val id: String,
+    val title: String,
+    val kind: VideoKind,
+    val yearLabel: String = "",
+    val runtimeLabel: String = "",
+    val overview: String = "",
+    val posterUrl: String? = null,
+    val backdropUrl: String? = null,
+    val artColor: Color = Color(0xFF6C8A7A),
+    val runtimeMs: Long = 0L,
+    val resumePositionMs: Long = 0L,
+    val seriesName: String? = null,
+    val seasonEpisodeLabel: String? = null,
+)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/Components.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/Components.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import pe.net.libre.mixtapehaven.model.Album
 import pe.net.libre.mixtapehaven.model.Track
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
 import pe.net.libre.mixtapehaven.ui.theme.Accent
 import pe.net.libre.mixtapehaven.ui.theme.AccentInk
 import pe.net.libre.mixtapehaven.ui.theme.Stroke
@@ -345,6 +347,41 @@ fun AlbumCard(album: Album, modifier: Modifier = Modifier, onClick: () -> Unit =
         }
         Text(album.title, style = MaterialTheme.typography.titleMedium, color = TextPrimary, maxLines = 1, overflow = TextOverflow.Ellipsis)
         Text(album.artist, style = MaterialTheme.typography.bodySmall, color = TextSecondary, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
+}
+
+/** Portrait 2:3 poster tile for a movie or TV series (Home "Movies & shows" row). */
+@Composable
+fun PosterCard(
+    video: VideoItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val meta = listOfNotNull(
+        video.yearLabel.ifEmpty { null },
+        if (video.kind == VideoKind.SERIES) "Series" else video.runtimeLabel.ifEmpty { null },
+    ).joinToString(" · ")
+    Column(
+        modifier = modifier.width(120.dp).clickable(onClick = onClick),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Artwork(
+            video.artColor,
+            video.posterUrl,
+            Modifier.fillMaxWidth().aspectRatio(2f / 3f),
+            corner = 12.dp,
+        )
+        Text(
+            video.title,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = TextPrimary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+        if (meta.isNotEmpty()) {
+            Text(meta, style = MaterialTheme.typography.labelSmall, color = TextSecondary, maxLines = 1)
+        }
     }
 }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeDestinations.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeDestinations.kt
@@ -7,4 +7,9 @@ object Routes {
     const val NOW_PLAYING = "now_playing"
     const val SETTINGS = "settings"
     const val DOWNLOADS = "downloads"
+    const val VIDEO_DETAIL = "video_detail/{itemId}"
+    const val VIDEO_PLAYER = "video_player/{itemId}"
+
+    fun videoDetail(itemId: String) = "video_detail/$itemId"
+    fun videoPlayer(itemId: String) = "video_player/$itemId"
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
@@ -3,6 +3,8 @@ package pe.net.libre.mixtapehaven.ui.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -14,6 +16,8 @@ import pe.net.libre.mixtapehaven.ui.screens.login.LoginScreen
 import pe.net.libre.mixtapehaven.ui.screens.nowplaying.NowPlayingScreen
 import pe.net.libre.mixtapehaven.ui.screens.search.SearchScreen
 import pe.net.libre.mixtapehaven.ui.screens.settings.SettingsScreen
+import pe.net.libre.mixtapehaven.ui.screens.video.VideoDetailScreen
+import pe.net.libre.mixtapehaven.ui.screens.video.VideoPlayerScreen
 
 @Composable
 fun MixtapeNavHost(startDestination: String, modifier: Modifier = Modifier) {
@@ -41,8 +45,10 @@ fun MixtapeNavHost(startDestination: String, modifier: Modifier = Modifier) {
                 onOpenSearch = { navController.navigate(Routes.SEARCH) },
                 onOpenDownloads = { navController.navigate(Routes.DOWNLOADS) },
                 onOpenNowPlaying = { navController.navigate(Routes.NOW_PLAYING) },
+                onOpenVideo = { itemId -> navController.navigate(Routes.videoDetail(itemId)) },
             )
         }
+        videoDestinations(navController)
         composable(Routes.SEARCH) {
             SearchScreen(
                 onBack = { navController.popBackStack() },
@@ -68,5 +74,22 @@ fun MixtapeNavHost(startDestination: String, modifier: Modifier = Modifier) {
         composable(Routes.DOWNLOADS) {
             DownloadsScreen(onBack = { navController.popBackStack() })
         }
+    }
+}
+
+/** Video detail + full-screen player destinations, both keyed by the Jellyfin item id. */
+private fun NavGraphBuilder.videoDestinations(navController: NavHostController) {
+    composable(Routes.VIDEO_DETAIL) { entry ->
+        VideoDetailScreen(
+            itemId = entry.arguments?.getString("itemId").orEmpty(),
+            onBack = { navController.popBackStack() },
+            onPlay = { playId -> navController.navigate(Routes.videoPlayer(playId)) },
+        )
+    }
+    composable(Routes.VIDEO_PLAYER) { entry ->
+        VideoPlayerScreen(
+            itemId = entry.arguments?.getString("itemId").orEmpty(),
+            onBack = { navController.popBackStack() },
+        )
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -45,10 +46,14 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import pe.net.libre.mixtapehaven.R
 import pe.net.libre.mixtapehaven.di.appViewModel
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import pe.net.libre.mixtapehaven.model.Album
 import pe.net.libre.mixtapehaven.model.Track
+import pe.net.libre.mixtapehaven.model.VideoItem
 import pe.net.libre.mixtapehaven.ui.components.AlbumCard
 import pe.net.libre.mixtapehaven.ui.components.NowPlayingBar
+import pe.net.libre.mixtapehaven.ui.components.PosterCard
 import pe.net.libre.mixtapehaven.ui.components.RandomWalkCard
 import pe.net.libre.mixtapehaven.ui.components.SearchField
 import pe.net.libre.mixtapehaven.ui.components.SectionHeader
@@ -68,6 +73,7 @@ fun HomeScreen(
     onOpenSearch: () -> Unit,
     onOpenDownloads: () -> Unit,
     onOpenNowPlaying: () -> Unit,
+    onOpenVideo: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val viewModel = appViewModel {
@@ -101,69 +107,107 @@ fun HomeScreen(
                 onOpenSettings = onOpenSettings,
             )
 
-            RandomWalkCard(
-                onPlay = {
-                    viewModel.startRandomWalk()
-                    onOpenNowPlaying()
-                },
-            )
+            RandomWalkCard(onPlay = { viewModel.startRandomWalk(); onOpenNowPlaying() })
 
             SearchField(
                 placeholder = "Search songs, albums, artists",
                 onClick = onOpenSearch,
             )
 
-            if (hasDownloads) {
-                OnDeviceSection(
-                    tracks = state.onDevice,
-                    onManage = onOpenDownloads,
-                    onPlay = { track ->
-                        viewModel.playOnDevice(track)
-                        onOpenNowPlaying()
-                    },
-                )
-            }
-
-            SectionHeader(
-                title = "Recently added",
-                actionLabel = "See all",
-                onAction = onOpenDownloads,
+            HomeSections(
+                state = state,
+                onOpenDownloads = onOpenDownloads,
+                onOpenSettings = onOpenSettings,
+                onOpenVideo = onOpenVideo,
+                onPlayTrack = { viewModel.playOnDevice(it); onOpenNowPlaying() },
+                onPlayAlbum = { viewModel.playAlbum(it); onOpenNowPlaying() },
+                onRetry = viewModel::load,
             )
-
-            when {
-                state.albums.isNotEmpty() -> AlbumGrid(
-                    albums = state.albums,
-                    onAlbumClick = { album ->
-                        viewModel.playAlbum(album)
-                        onOpenNowPlaying()
-                    },
-                )
-                // Fetch in flight: render nothing rather than flash an empty state.
-                state.loading -> Unit
-                state.error != null -> OfflineAlbumsState(onRetry = viewModel::load)
-                else -> FirstRunEmptyState(onOpenSettings = onOpenSettings)
-            }
         }
 
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .navigationBarsPadding()
-                .padding(16.dp)
-                .padding(bottom = if (nowPlayingTrack != null) 68.dp else 0.dp),
+        HomeOverlays(
+            snackbarHostState = snackbarHostState,
+            nowPlaying = nowPlayingTrack,
+            isPlaying = isPlaying,
+            onOpenNowPlaying = onOpenNowPlaying,
+            onPlayPause = viewModel::playPause,
+            onNext = viewModel::playNext,
         )
+    }
+}
 
-        nowPlayingTrack?.let { track ->
-            NowPlayingBar(
-                track = track,
-                isPlaying = isPlaying,
-                onOpen = onOpenNowPlaying,
-                onPlayPause = viewModel::playPause,
-                onNext = viewModel::playNext,
-                modifier = Modifier.align(Alignment.BottomCenter),
-            )
-        }
+/** Bottom-anchored transient UI: the snackbar and, while something plays, the Now Playing bar. */
+@Composable
+private fun BoxScope.HomeOverlays(
+    snackbarHostState: SnackbarHostState,
+    nowPlaying: Track?,
+    isPlaying: Boolean,
+    onOpenNowPlaying: () -> Unit,
+    onPlayPause: () -> Unit,
+    onNext: () -> Unit,
+) {
+    SnackbarHost(
+        hostState = snackbarHostState,
+        modifier = Modifier
+            .align(Alignment.BottomCenter)
+            .navigationBarsPadding()
+            .padding(16.dp)
+            .padding(bottom = if (nowPlaying != null) 68.dp else 0.dp),
+    )
+
+    nowPlaying?.let { track ->
+        NowPlayingBar(
+            track = track,
+            isPlaying = isPlaying,
+            onOpen = onOpenNowPlaying,
+            onPlayPause = onPlayPause,
+            onNext = onNext,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+/** The library sections of Home: saved tracks, Movies & shows, and the Recently added grid. */
+@Composable
+private fun HomeSections(
+    state: HomeViewModel.UiState,
+    onOpenDownloads: () -> Unit,
+    onOpenSettings: () -> Unit,
+    onOpenVideo: (String) -> Unit,
+    onPlayTrack: (Track) -> Unit,
+    onPlayAlbum: (Album) -> Unit,
+    onRetry: () -> Unit,
+) {
+    if (state.onDevice.isNotEmpty()) {
+        OnDeviceSection(
+            tracks = state.onDevice,
+            onManage = onOpenDownloads,
+            onPlay = onPlayTrack,
+        )
+    }
+
+    if (state.videos.isNotEmpty()) {
+        MoviesAndShowsSection(
+            videos = state.videos,
+            onVideoClick = { onOpenVideo(it.id) },
+        )
+    }
+
+    SectionHeader(
+        title = "Recently added",
+        actionLabel = "See all",
+        onAction = onOpenDownloads,
+    )
+
+    when {
+        state.albums.isNotEmpty() -> AlbumGrid(
+            albums = state.albums,
+            onAlbumClick = onPlayAlbum,
+        )
+        // Fetch in flight: render nothing rather than flash an empty state.
+        state.loading -> Unit
+        state.error != null -> OfflineAlbumsState(onRetry = onRetry)
+        else -> FirstRunEmptyState(onOpenSettings = onOpenSettings)
     }
 }
 
@@ -227,6 +271,20 @@ private fun OnDeviceSection(
     Column {
         tracks.take(ON_DEVICE_PREVIEW).forEach { track ->
             TrackRow(track = track, onClick = { onPlay(track) })
+        }
+    }
+}
+
+/** Horizontal poster rail of the user's movies and TV series. */
+@Composable
+private fun MoviesAndShowsSection(
+    videos: List<VideoItem>,
+    onVideoClick: (VideoItem) -> Unit,
+) {
+    SectionHeader(title = "Movies & shows")
+    LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        items(videos, key = { it.id }) { video ->
+            PosterCard(video = video, onClick = { onVideoClick(video) })
         }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -64,9 +65,12 @@ class HomeViewModel(
         viewModelScope.launch {
             val userName = repository.session.first()?.userName.orEmpty()
             // A server without video libraries (or a video fetch failure) must not break the
-            // music Home, so videos degrade to an empty (hidden) section independently.
-            val videos = runCatching { repository.moviesAndShows() }.getOrDefault(emptyList())
-            runCatching { repository.recentlyAddedAlbums() }.fold(
+            // music Home, so videos degrade to an empty (hidden) section independently — and load
+            // in parallel so the new section adds no latency to the album fetch.
+            val videosDeferred = async { runCatching { repository.moviesAndShows() }.getOrDefault(emptyList()) }
+            val albumsResult = runCatching { repository.recentlyAddedAlbums() }
+            val videos = videosDeferred.await()
+            albumsResult.fold(
                 onSuccess = { albums ->
                     _state.update { it.copy(userName = userName, albums = albums, videos = videos, loading = false) }
                 },

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -24,6 +24,7 @@ import pe.net.libre.mixtapehaven.data.playback.PlayerController
 import pe.net.libre.mixtapehaven.data.playback.RandomWalk
 import pe.net.libre.mixtapehaven.model.Album
 import pe.net.libre.mixtapehaven.model.Track
+import pe.net.libre.mixtapehaven.model.VideoItem
 
 class HomeViewModel(
     private val repository: JellyfinRepository,
@@ -35,6 +36,7 @@ class HomeViewModel(
     data class UiState(
         val userName: String = "",
         val albums: List<Album> = emptyList(),
+        val videos: List<VideoItem> = emptyList(),
         val onDevice: List<Track> = emptyList(),
         val loading: Boolean = true,
         val error: String? = null,
@@ -61,14 +63,18 @@ class HomeViewModel(
         _state.update { it.copy(loading = true, error = null) }
         viewModelScope.launch {
             val userName = repository.session.first()?.userName.orEmpty()
+            // A server without video libraries (or a video fetch failure) must not break the
+            // music Home, so videos degrade to an empty (hidden) section independently.
+            val videos = runCatching { repository.moviesAndShows() }.getOrDefault(emptyList())
             runCatching { repository.recentlyAddedAlbums() }.fold(
                 onSuccess = { albums ->
-                    _state.update { it.copy(userName = userName, albums = albums, loading = false) }
+                    _state.update { it.copy(userName = userName, albums = albums, videos = videos, loading = false) }
                 },
                 onFailure = { error ->
                     _state.update {
                         it.copy(
                             userName = userName,
+                            videos = videos,
                             loading = false,
                             error = error.message ?: "Could not load your library",
                         )

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailScreen.kt
@@ -1,0 +1,251 @@
+package pe.net.libre.mixtapehaven.ui.screens.video
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import pe.net.libre.mixtapehaven.di.appViewModel
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
+import pe.net.libre.mixtapehaven.ui.components.Artwork
+import pe.net.libre.mixtapehaven.ui.theme.Accent
+import pe.net.libre.mixtapehaven.ui.theme.AccentInk
+import pe.net.libre.mixtapehaven.ui.theme.Surface2
+import pe.net.libre.mixtapehaven.ui.theme.TextMuted
+import pe.net.libre.mixtapehaven.ui.theme.TextPrimary
+import pe.net.libre.mixtapehaven.ui.theme.TextSecondary
+
+@Composable
+fun VideoDetailScreen(
+    itemId: String,
+    onBack: () -> Unit,
+    onPlay: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val viewModel = appViewModel { VideoDetailViewModel(it.repository, itemId) }
+    val state by viewModel.state.collectAsState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .navigationBarsPadding(),
+    ) {
+        Backdrop(item = state.item, onBack = onBack)
+
+        val item = state.item
+        when {
+            item != null -> DetailBody(
+                item = item,
+                episodes = state.episodes,
+                onPlay = { viewModel.playTarget()?.let { onPlay(it.id) } },
+                onPlayEpisode = { onPlay(it.id) },
+            )
+            state.loading -> Unit
+            else -> Text(
+                state.error ?: "Could not load this title",
+                style = MaterialTheme.typography.bodyMedium,
+                color = TextSecondary,
+                modifier = Modifier.padding(20.dp),
+            )
+        }
+    }
+}
+
+/** Wide backdrop image with the back control overlaid, falling back to the tinted poster art. */
+@Composable
+private fun Backdrop(item: VideoItem?, onBack: () -> Unit) {
+    Box(Modifier.fillMaxWidth()) {
+        Artwork(
+            color = item?.artColor ?: Surface2,
+            imageUrl = item?.backdropUrl ?: item?.posterUrl,
+            modifier = Modifier.fillMaxWidth().aspectRatio(16f / 9f),
+            corner = 0.dp,
+        )
+        Box(
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(12.dp)
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(AccentInk.copy(alpha = 0.55f))
+                .clickable(role = Role.Button, onClick = onBack),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Outlined.ArrowBack,
+                contentDescription = "Back",
+                tint = TextPrimary,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetailBody(
+    item: VideoItem,
+    episodes: List<VideoItem>,
+    onPlay: () -> Unit,
+    onPlayEpisode: (VideoItem) -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(item.title, style = MaterialTheme.typography.displayMedium, color = TextPrimary)
+            val meta = listOfNotNull(
+                item.yearLabel.ifEmpty { null },
+                when (item.kind) {
+                    VideoKind.SERIES -> "Series"
+                    else -> item.runtimeLabel.ifEmpty { null }
+                },
+            ).joinToString(" · ")
+            if (meta.isNotEmpty()) {
+                Text(meta, style = MaterialTheme.typography.bodySmall, color = TextSecondary)
+            }
+        }
+
+        PlayButton(
+            label = if (item.kind != VideoKind.SERIES && item.resumePositionMs > 0) "Resume" else "Play",
+            onClick = onPlay,
+        )
+
+        if (item.overview.isNotEmpty()) {
+            Text(item.overview, style = MaterialTheme.typography.bodyMedium, color = TextSecondary)
+        }
+
+        if (episodes.isNotEmpty()) {
+            Text("Episodes", style = MaterialTheme.typography.titleMedium, color = TextPrimary)
+            Column {
+                episodes.forEach { episode ->
+                    EpisodeRow(episode = episode, onClick = { onPlayEpisode(episode) })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayButton(label: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(Accent)
+            .clickable(role = Role.Button, onClick = onClick)
+            .padding(vertical = 14.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(Icons.Filled.PlayArrow, contentDescription = null, tint = AccentInk, modifier = Modifier.size(20.dp))
+        Spacer(Modifier.width(8.dp))
+        Text(
+            label,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = AccentInk,
+        )
+    }
+}
+
+/** 16:9 episode still with a resume progress bar overlaid when the episode was started. */
+@Composable
+private fun EpisodeThumb(episode: VideoItem) {
+    Box {
+        Artwork(
+            color = episode.artColor,
+            imageUrl = episode.posterUrl,
+            modifier = Modifier.width(112.dp).aspectRatio(16f / 9f),
+            corner = 8.dp,
+        )
+        if (episode.resumePositionMs > 0 && episode.runtimeMs > 0) {
+            val fraction = (episode.resumePositionMs.toFloat() / episode.runtimeMs).coerceIn(0f, 1f)
+            Row(
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(horizontal = 6.dp, vertical = 5.dp)
+                    .fillMaxWidth()
+                    .height(3.dp)
+                    .clip(CircleShape)
+                    .background(AccentInk.copy(alpha = 0.6f)),
+            ) {
+                Box(
+                    Modifier
+                        .fillMaxWidth(fraction)
+                        .height(3.dp)
+                        .background(Accent),
+                )
+            }
+        }
+    }
+}
+
+/** One episode: 16:9 still, title, "S2 E4 · 42m" meta, with a resume progress bar when started. */
+@Composable
+private fun EpisodeRow(episode: VideoItem, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        EpisodeThumb(episode)
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                episode.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = TextPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            val meta = listOfNotNull(
+                episode.seasonEpisodeLabel,
+                episode.runtimeLabel.ifEmpty { null },
+            ).joinToString(" · ")
+            if (meta.isNotEmpty()) {
+                Text(meta, style = MaterialTheme.typography.bodySmall, color = TextMuted)
+            }
+        }
+        Icon(
+            Icons.Filled.PlayArrow,
+            contentDescription = "Play episode",
+            tint = TextSecondary,
+            modifier = Modifier.size(22.dp),
+        )
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailViewModel.kt
@@ -48,17 +48,20 @@ class VideoDetailViewModel(
         }
     }
 
-    /**
-     * The item playback should start with: the movie/episode itself, or for a series the first
-     * in-progress episode, falling back to the first episode. Null while loading or on error.
-     */
-    fun playTarget(): VideoItem? {
-        val current = _state.value
-        val item = current.item
-        return when {
-            item == null -> null
-            item.kind != VideoKind.SERIES -> item
-            else -> current.episodes.firstOrNull { it.resumePositionMs > 0 } ?: current.episodes.firstOrNull()
-        }
-    }
+    /** See [selectPlayTarget]. Null while loading or on error. */
+    fun playTarget(): VideoItem? = selectPlayTarget(_state.value.item, _state.value.episodes)
+}
+
+/**
+ * The item playback should start with: the movie/episode itself, or for a series the first
+ * in-progress episode, falling back to the first episode.
+ *
+ * Known limitation: once an episode is watched to completion Jellyfin zeroes its position, so a
+ * user who finished E1 (with nothing in progress) is sent to E1 again instead of E2. Switching to
+ * tvShowsApi.getNextUp would solve exactly this.
+ */
+internal fun selectPlayTarget(item: VideoItem?, episodes: List<VideoItem>): VideoItem? = when {
+    item == null -> null
+    item.kind != VideoKind.SERIES -> item
+    else -> episodes.firstOrNull { it.resumePositionMs > 0 } ?: episodes.firstOrNull()
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailViewModel.kt
@@ -1,0 +1,64 @@
+package pe.net.libre.mixtapehaven.ui.screens.video
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
+
+class VideoDetailViewModel(
+    private val repository: JellyfinRepository,
+    private val itemId: String,
+) : ViewModel() {
+
+    data class UiState(
+        val item: VideoItem? = null,
+        val episodes: List<VideoItem> = emptyList(),
+        val loading: Boolean = true,
+        val error: String? = null,
+    )
+
+    private val _state = MutableStateFlow(UiState())
+    val state: StateFlow<UiState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        _state.update { it.copy(loading = true, error = null) }
+        viewModelScope.launch {
+            runCatching {
+                val item = requireNotNull(repository.videoItem(itemId)) { "Item not found" }
+                val episodes = if (item.kind == VideoKind.SERIES) repository.seriesEpisodes(itemId) else emptyList()
+                item to episodes
+            }.fold(
+                onSuccess = { (item, episodes) ->
+                    _state.update { it.copy(item = item, episodes = episodes, loading = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(loading = false, error = error.message ?: "Could not load this title") }
+                },
+            )
+        }
+    }
+
+    /**
+     * The item playback should start with: the movie/episode itself, or for a series the first
+     * in-progress episode, falling back to the first episode. Null while loading or on error.
+     */
+    fun playTarget(): VideoItem? {
+        val current = _state.value
+        val item = current.item
+        return when {
+            item == null -> null
+            item.kind != VideoKind.SERIES -> item
+            else -> current.episodes.firstOrNull { it.resumePositionMs > 0 } ?: current.episodes.firstOrNull()
+        }
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -25,6 +26,9 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.PlayerView
 import pe.net.libre.mixtapehaven.di.appViewModel
@@ -45,6 +49,17 @@ fun VideoPlayerScreen(
     }
     val error by viewModel.error.collectAsState()
 
+    // No background video service exists, so pause when the screen stops (Home button, lock);
+    // otherwise audio would keep playing invisibly and the progress loop would churn the radio.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, viewModel) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP) viewModel.onScreenStopped()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     Box(modifier = modifier.fillMaxSize().background(Color.Black)) {
         AndroidView(
             factory = { context ->
@@ -55,6 +70,7 @@ fun VideoPlayerScreen(
                     keepScreenOn = true
                 }
             },
+            onRelease = { it.player = null },
             modifier = Modifier.fillMaxSize(),
         )
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
@@ -1,0 +1,86 @@
+package pe.net.libre.mixtapehaven.ui.screens.video
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.ui.PlayerView
+import pe.net.libre.mixtapehaven.di.appViewModel
+import pe.net.libre.mixtapehaven.ui.theme.TextPrimary
+
+/** Full-screen video playback surface using media3's [PlayerView] for transport controls. */
+@Composable
+fun VideoPlayerScreen(
+    itemId: String,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val appContext = LocalContext.current.applicationContext
+    val viewModel = appViewModel {
+        VideoPlayerViewModel(appContext, it.repository, it.playerController, itemId, it.videoSourceResolver)
+    }
+    val error by viewModel.error.collectAsState()
+
+    Box(modifier = modifier.fillMaxSize().background(Color.Black)) {
+        AndroidView(
+            factory = { context ->
+                PlayerView(context).apply {
+                    player = viewModel.player
+                    setShowNextButton(false)
+                    setShowPreviousButton(false)
+                    keepScreenOn = true
+                }
+            },
+            modifier = Modifier.fillMaxSize(),
+        )
+
+        error?.let { message ->
+            Text(
+                message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = TextPrimary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.align(Alignment.Center).padding(32.dp),
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(12.dp)
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(Color.Black.copy(alpha = 0.45f))
+                .clickable(role = Role.Button, onClick = onBack),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Outlined.ArrowBack,
+                contentDescription = "Back",
+                tint = TextPrimary,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
@@ -25,11 +25,14 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.PlayerView
 import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.ui.theme.TextPrimary
 
 /** Full-screen video playback surface using media3's [PlayerView] for transport controls. */
+// PlayerView and its show/hide-button setters are @UnstableApi; media3 requires an explicit opt-in.
+@androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun VideoPlayerScreen(
     itemId: String,

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
@@ -1,0 +1,109 @@
+package pe.net.libre.mixtapehaven.ui.screens.video
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
+import pe.net.libre.mixtapehaven.data.jellyfin.VideoPlaybackEvent
+import pe.net.libre.mixtapehaven.data.playback.PlayerController
+
+/**
+ * Owns the video [player] (a separate ExoPlayer instance from the music stack) so playback
+ * survives configuration changes. Pauses music on start, resumes from the server-side position,
+ * and reports start/progress/stopped back to Jellyfin so Continue Watching stays in sync.
+ *
+ * Stream sources come from [resolveSources] as ordered candidates (direct play first, HLS
+ * transcode fallback); a playback error falls through to the next candidate at the same position.
+ */
+class VideoPlayerViewModel(
+    context: Context,
+    private val repository: JellyfinRepository,
+    musicController: PlayerController,
+    private val itemId: String,
+    private val resolveSources: (String) -> List<String>,
+) : ViewModel() {
+
+    val player: ExoPlayer = ExoPlayer.Builder(context.applicationContext).build()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private var candidates: List<String> = emptyList()
+    private var candidateIndex = 0
+
+    private val listener = object : Player.Listener {
+        override fun onPlayerError(error: PlaybackException) {
+            // Direct play failed (e.g. a codec the device can't decode): fall through to the
+            // transcoded candidate, keeping the position already reached.
+            val positionMs = player.currentPosition.coerceAtLeast(0)
+            if (candidateIndex + 1 < candidates.size) {
+                candidateIndex++
+                prepareCurrentCandidate(startMs = positionMs)
+            } else {
+                _error.value = error.message ?: "Playback failed"
+            }
+        }
+    }
+
+    init {
+        // One audio stream at a time: the video player takes over, music keeps its queue.
+        musicController.pause()
+        player.addListener(listener)
+        player.playWhenReady = true
+        viewModelScope.launch {
+            val resumeMs = runCatching { repository.videoItem(itemId) }
+                .getOrNull()?.resumePositionMs ?: 0L
+            candidates = resolveSources(itemId)
+            if (candidates.isEmpty()) {
+                _error.value = "No playable source for this title"
+                return@launch
+            }
+            prepareCurrentCandidate(startMs = resumeMs)
+            repository.reportVideoPlayback(itemId, resumeMs, VideoPlaybackEvent.STARTED)
+            while (isActive) {
+                delay(PROGRESS_REPORT_MS)
+                if (player.playbackState == Player.STATE_READY) {
+                    repository.reportVideoPlayback(
+                        itemId,
+                        player.currentPosition,
+                        VideoPlaybackEvent.PROGRESS,
+                        paused = !player.isPlaying,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun prepareCurrentCandidate(startMs: Long) {
+        player.setMediaItem(MediaItem.fromUri(candidates[candidateIndex]), startMs)
+        player.prepare()
+    }
+
+    override fun onCleared() {
+        val positionMs = player.currentPosition.coerceAtLeast(0)
+        player.removeListener(listener)
+        player.release()
+        // viewModelScope is already cancelled here, so the final report (which fixes the server's
+        // resume point) needs its own short-lived scope.
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            repository.reportVideoPlayback(itemId, positionMs, VideoPlaybackEvent.STOPPED)
+        }
+    }
+
+    private companion object {
+        const val PROGRESS_REPORT_MS = 10_000L
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
@@ -3,6 +3,8 @@ package pe.net.libre.mixtapehaven.ui.screens.video
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
@@ -10,6 +12,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,7 +39,17 @@ class VideoPlayerViewModel(
     private val resolveSources: (String) -> List<String>,
 ) : ViewModel() {
 
-    val player: ExoPlayer = ExoPlayer.Builder(context.applicationContext).build()
+    val player: ExoPlayer = ExoPlayer.Builder(context.applicationContext)
+        // handleAudioFocus ducks/pauses other apps' audio and pauses us for calls; without it the
+        // raw player would play over Spotify etc. (musicController.pause() only covers our music).
+        .setAudioAttributes(
+            AudioAttributes.Builder()
+                .setUsage(C.USAGE_MEDIA)
+                .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+                .build(),
+            /* handleAudioFocus = */ true,
+        )
+        .build()
 
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
@@ -44,7 +57,14 @@ class VideoPlayerViewModel(
     private var candidates: List<String> = emptyList()
     private var candidateIndex = 0
 
+    /** True once any candidate actually played; gates the STOPPED report in [onCleared]. */
+    private var reachedReady = false
+
     private val listener = object : Player.Listener {
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            if (playbackState == Player.STATE_READY) reachedReady = true
+        }
+
         override fun onPlayerError(error: PlaybackException) {
             // Direct play failed (e.g. a codec the device can't decode): fall through to the
             // transcoded candidate, keeping the position already reached.
@@ -73,18 +93,45 @@ class VideoPlayerViewModel(
             }
             prepareCurrentCandidate(startMs = resumeMs)
             repository.reportVideoPlayback(itemId, resumeMs, VideoPlaybackEvent.STARTED)
-            while (isActive) {
-                delay(PROGRESS_REPORT_MS)
-                if (player.playbackState == Player.STATE_READY) {
-                    repository.reportVideoPlayback(
-                        itemId,
-                        player.currentPosition,
-                        VideoPlaybackEvent.PROGRESS,
-                        paused = !player.isPlaying,
-                    )
+            reportProgressLoop()
+        }
+    }
+
+    /** Pause playback when the screen is no longer visible; there is no background video service. */
+    fun onScreenStopped() {
+        player.pause()
+    }
+
+    /**
+     * Report progress every [PROGRESS_REPORT_MS] while playing, plus exactly one paused report per
+     * pause (so the resume point lands) — then stay quiet to avoid indefinite idle network churn.
+     */
+    private suspend fun reportProgressLoop() {
+        var reportedPause = false
+        while (currentCoroutineContext().isActive) {
+            delay(PROGRESS_REPORT_MS)
+            val ready = player.playbackState == Player.STATE_READY
+            when {
+                ready && player.isPlaying -> {
+                    reportedPause = false
+                    reportProgress(paused = false)
+                }
+                ready && !reportedPause -> {
+                    reportedPause = true
+                    reportProgress(paused = true)
                 }
             }
         }
+    }
+
+    private suspend fun reportProgress(paused: Boolean) {
+        repository.reportVideoPlayback(
+            itemId,
+            player.currentPosition,
+            VideoPlaybackEvent.PROGRESS,
+            paused = paused,
+            transcoding = candidateIndex > 0,
+        )
     }
 
     private fun prepareCurrentCandidate(startMs: Long) {
@@ -94,12 +141,22 @@ class VideoPlayerViewModel(
 
     override fun onCleared() {
         val positionMs = player.currentPosition.coerceAtLeast(0)
+        val playedSomething = reachedReady
+        val transcoding = candidateIndex > 0
         player.removeListener(listener)
         player.release()
+        // A session that never played must not report STOPPED: its position 0 would regress the
+        // server-side resume point of a half-watched item.
+        if (!playedSomething) return
         // viewModelScope is already cancelled here, so the final report (which fixes the server's
         // resume point) needs its own short-lived scope.
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
-            repository.reportVideoPlayback(itemId, positionMs, VideoPlaybackEvent.STOPPED)
+            repository.reportVideoPlayback(
+                itemId,
+                positionMs,
+                VideoPlaybackEvent.STOPPED,
+                transcoding = transcoding,
+            )
         }
     }
 

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinVideoMappingTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinVideoMappingTest.kt
@@ -1,0 +1,30 @@
+package pe.net.libre.mixtapehaven.data.jellyfin
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class JellyfinVideoMappingTest {
+
+    @Test
+    fun `formatRuntime renders hours and minutes`() {
+        assertEquals("1h 14m", formatRuntime(74 * 60_000L))
+        assertEquals("2h 0m", formatRuntime(120 * 60_000L))
+    }
+
+    @Test
+    fun `formatRuntime renders minutes only under an hour`() {
+        assertEquals("42m", formatRuntime(42 * 60_000L))
+        assertEquals("1m", formatRuntime(60_000L))
+    }
+
+    @Test
+    fun `formatRuntime is empty for zero or negative`() {
+        assertEquals("", formatRuntime(0))
+        assertEquals("", formatRuntime(-5))
+    }
+
+    @Test
+    fun `videoColorFor is deterministic per key`() {
+        assertEquals(videoColorFor("abc"), videoColorFor("abc"))
+    }
+}

--- a/app/src/test/java/pe/net/libre/mixtapehaven/ui/screens/video/SelectPlayTargetTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/ui/screens/video/SelectPlayTargetTest.kt
@@ -1,0 +1,51 @@
+package pe.net.libre.mixtapehaven.ui.screens.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
+
+/** Unit coverage for the series-resume selection behind the detail screen's Play/Resume button. */
+class SelectPlayTargetTest {
+
+    private fun video(id: String, kind: VideoKind, resumeMs: Long = 0) =
+        VideoItem(id = id, title = id, kind = kind, resumePositionMs = resumeMs)
+
+    @Test
+    fun `null item yields no target`() {
+        assertNull(selectPlayTarget(null, emptyList()))
+    }
+
+    @Test
+    fun `movie plays itself regardless of episodes`() {
+        val movie = video("m", VideoKind.MOVIE)
+
+        assertEquals(movie, selectPlayTarget(movie, listOf(video("e1", VideoKind.EPISODE))))
+    }
+
+    @Test
+    fun `series plays the first in-progress episode`() {
+        val series = video("s", VideoKind.SERIES)
+        val episodes = listOf(
+            video("e1", VideoKind.EPISODE),
+            video("e2", VideoKind.EPISODE, resumeMs = 60_000),
+            video("e3", VideoKind.EPISODE, resumeMs = 5_000),
+        )
+
+        assertEquals("e2", selectPlayTarget(series, episodes)?.id)
+    }
+
+    @Test
+    fun `series with nothing in progress falls back to the first episode`() {
+        val series = video("s", VideoKind.SERIES)
+        val episodes = listOf(video("e1", VideoKind.EPISODE), video("e2", VideoKind.EPISODE))
+
+        assertEquals("e1", selectPlayTarget(series, episodes)?.id)
+    }
+
+    @Test
+    fun `series without episodes yields no target`() {
+        assertNull(selectPlayTarget(video("s", VideoKind.SERIES), emptyList()))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
 media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "media3" }
+media3-exoplayer-hls = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3" }
 media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "media3" }
 media3-datasource-okhttp = { group = "androidx.media3", name = "media3-datasource-okhttp", version.ref = "media3" }
 androidx-media = { group = "androidx.media", name = "media", version.ref = "media" }


### PR DESCRIPTION
## Summary

First slice of video support: browse and **stream** movies & TV series from the Jellyfin server. Streaming-only by design — the manual mark-for-download pipeline (quality-capped transcodes) comes in a later step and plugs into a seam this PR leaves in place.

- **Data**: `VideoItem` model; repository queries for movies/series listing, item detail (with the user's resume position), and series episodes; `videoStreamCandidates()` returns ordered sources — direct play first, HLS h264/aac transcode fallback; `reportVideoPlayback()` sends started/progress/stopped playstate so the server resume point (and Continue Watching) stays in sync. DTO mapping lives in `JellyfinVideoMapping.kt`.
- **Home**: new "Movies & shows" horizontal poster rail (`PosterCard`, 2:3 portrait). Hidden when the server has no video items; a video fetch failure degrades to a hidden section and can't break the music Home.
- **Video Detail** (`video_detail/{itemId}`): backdrop with back overlay, title/meta, Play/Resume, overview, and an episode list with resume progress bars for series. For a series, Play targets the first in-progress episode.
- **Video Player** (`video_player/{itemId}`): second ExoPlayer instance owned by the ViewModel (survives rotation), media3 `PlayerView` transport controls, pauses music on start via new `PlayerController.pause()` (queue preserved). Resumes from the server position; on playback error falls through to the next stream candidate at the same position. Sources resolve via `AppContainer.videoSourceResolver` — the future hook for serving local downloads first, mirroring the audio `streamUrlResolver`.
- **Deps**: `media3-ui`, `media3-exoplayer-hls`.

## Test plan

- [x] `gradlew detekt` and unit tests pass
- [x] Verified on device (Pixel) against `https://demo.jellyfin.org/stable`: Home shows the poster rail with real artwork/meta → Dracula detail shows backdrop/overview and **Resume** → playback direct-plays, resumed from the server-side position (12:32 / 1:14:26), transport controls work → back reports stopped; re-entering resumes from a server position again
- [x] No video libraries / fetch failure: section hidden, music Home unaffected
- [ ] HLS fallback path (needs a file the device can't direct-play)

🤖 Generated with [Claude Code](https://claude.com/claude-code)