### PR TITLE
feat: manual video downloads with quality-capped transcodes (video step 2)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,11 @@ tasks.named("check") {
     dependsOn("detekt")
 }
 
+// Room writes each version's schema JSON here so migrations are diffable in review and testable.
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 android {
     namespace = "pe.net.libre.mixtapehaven"
     compileSdk {

--- a/app/schemas/pe.net.libre.mixtapehaven.data.download.DownloadDatabase/2.json
+++ b/app/schemas/pe.net.libre.mixtapehaven.data.download.DownloadDatabase/2.json
@@ -1,0 +1,159 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "5fde0b08a96fddca055f76a018bf373e",
+    "entities": [
+      {
+        "tableName": "downloaded_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `durationLabel` TEXT NOT NULL, `imageUrl` TEXT, `artColorArgb` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `complete` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationLabel",
+            "columnName": "durationLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artColorArgb",
+            "columnName": "artColorArgb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "complete",
+            "columnName": "complete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "downloaded_videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `kind` TEXT NOT NULL, `seriesName` TEXT, `seasonEpisodeLabel` TEXT, `runtimeLabel` TEXT NOT NULL, `posterUrl` TEXT, `artColorArgb` INTEGER NOT NULL, `qualityLabel` TEXT NOT NULL, `filePath` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `complete` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonEpisodeLabel",
+            "columnName": "seasonEpisodeLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "runtimeLabel",
+            "columnName": "runtimeLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artColorArgb",
+            "columnName": "artColorArgb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "qualityLabel",
+            "columnName": "qualityLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "complete",
+            "columnName": "complete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5fde0b08a96fddca055f76a018bf373e')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
@@ -30,6 +31,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".data.download.VideoDownloadService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
 
         <service
             android:name=".data.playback.PlaybackService"

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDatabase.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDatabase.kt
@@ -4,20 +4,38 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
-/** Room database holding the offline download library. */
-@Database(entities = [DownloadedTrack::class], version = 1, exportSchema = false)
+/** Room database holding the offline download library (audio tracks and videos). */
+@Database(entities = [DownloadedTrack::class, DownloadedVideo::class], version = 2, exportSchema = false)
 abstract class DownloadDatabase : RoomDatabase() {
 
     abstract fun downloadDao(): DownloadDao
 
+    abstract fun videoDownloadDao(): VideoDownloadDao
+
     companion object {
+        /** v1 -> v2: adds the video download table. Additive so existing audio downloads survive. */
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `downloaded_videos` (" +
+                        "`id` TEXT NOT NULL, `title` TEXT NOT NULL, `kind` TEXT NOT NULL, " +
+                        "`seriesName` TEXT, `seasonEpisodeLabel` TEXT, `runtimeLabel` TEXT NOT NULL, " +
+                        "`posterUrl` TEXT, `artColorArgb` INTEGER NOT NULL, `qualityLabel` TEXT NOT NULL, " +
+                        "`filePath` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `complete` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`id`))",
+                )
+            }
+        }
+
         /** Build the app's download database in the default location. */
         fun build(context: Context): DownloadDatabase =
             Room.databaseBuilder(
                 context.applicationContext,
                 DownloadDatabase::class.java,
                 "downloads.db",
-            ).build()
+            ).addMigrations(MIGRATION_1_2).build()
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDatabase.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDatabase.kt
@@ -8,7 +8,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 /** Room database holding the offline download library (audio tracks and videos). */
-@Database(entities = [DownloadedTrack::class, DownloadedVideo::class], version = 2, exportSchema = false)
+@Database(entities = [DownloadedTrack::class, DownloadedVideo::class], version = 2, exportSchema = true)
 abstract class DownloadDatabase : RoomDatabase() {
 
     abstract fun downloadDao(): DownloadDao

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadSettingsStore.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadSettingsStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -12,11 +13,12 @@ import kotlinx.coroutines.flow.map
 private val Context.downloadSettingsDataStore: DataStore<Preferences> by
     preferencesDataStore(name = "download_settings")
 
-/** Persists download preferences (auto-download enabled) across app launches via DataStore. */
+/** Persists download preferences (auto-download, video quality) across app launches via DataStore. */
 class DownloadSettingsStore(private val context: Context) {
 
     private object Keys {
         val AUTO_DOWNLOAD = booleanPreferencesKey("auto_download_enabled")
+        val VIDEO_QUALITY = stringPreferencesKey("video_download_quality")
     }
 
     /** Whether tracks are saved for offline automatically as they play. Defaults to enabled. */
@@ -26,5 +28,14 @@ class DownloadSettingsStore(private val context: Context) {
 
     suspend fun setAutoDownloadEnabled(enabled: Boolean) {
         context.downloadSettingsDataStore.edit { it[Keys.AUTO_DOWNLOAD] = enabled }
+    }
+
+    /** The quality cap applied to video downloads. Defaults to [VideoDownloadQuality.DEFAULT]. */
+    val videoQuality: Flow<VideoDownloadQuality> = context.downloadSettingsDataStore.data.map { prefs ->
+        VideoDownloadQuality.fromName(prefs[Keys.VIDEO_QUALITY])
+    }
+
+    suspend fun setVideoQuality(quality: VideoDownloadQuality) {
+        context.downloadSettingsDataStore.edit { it[Keys.VIDEO_QUALITY] = quality.name }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadedVideo.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadedVideo.kt
@@ -1,0 +1,40 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import androidx.compose.ui.graphics.Color
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
+
+/**
+ * A movie or episode saved to local storage as a quality-capped transcode for offline playback.
+ * [kind] is the [VideoKind] name, [qualityLabel] the cap it was transcoded at (e.g. "720p").
+ * [complete] is false while bytes are still being written and true once the file is fully saved.
+ */
+@Entity(tableName = "downloaded_videos")
+data class DownloadedVideo(
+    @PrimaryKey val id: String,
+    val title: String,
+    val kind: String,
+    val seriesName: String?,
+    val seasonEpisodeLabel: String?,
+    val runtimeLabel: String,
+    val posterUrl: String?,
+    val artColorArgb: Int,
+    val qualityLabel: String,
+    val filePath: String,
+    val sizeBytes: Long,
+    val complete: Boolean,
+)
+
+/** Map a persisted video download back to a UI [VideoItem]. */
+internal fun DownloadedVideo.toVideoItem(): VideoItem = VideoItem(
+    id = id,
+    title = title,
+    kind = VideoKind.entries.firstOrNull { it.name == kind } ?: VideoKind.MOVIE,
+    runtimeLabel = runtimeLabel,
+    posterUrl = posterUrl,
+    artColor = Color(artColorArgb),
+    seriesName = seriesName,
+    seasonEpisodeLabel = seasonEpisodeLabel,
+)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadDao.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadDao.kt
@@ -1,0 +1,31 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+/** Room access to the offline video download library. */
+@Dao
+interface VideoDownloadDao {
+
+    /** All saved/in-progress video downloads, oldest first, observed for the UI. */
+    @Query("SELECT * FROM downloaded_videos ORDER BY rowid")
+    fun observeAll(): Flow<List<DownloadedVideo>>
+
+    /** Running total of bytes used by completed video downloads. */
+    @Query("SELECT COALESCE(SUM(sizeBytes), 0) FROM downloaded_videos WHERE complete = 1")
+    fun observeTotalSize(): Flow<Long>
+
+    @Upsert
+    suspend fun upsert(video: DownloadedVideo)
+
+    @Query("SELECT * FROM downloaded_videos WHERE id = :id")
+    suspend fun findById(id: String): DownloadedVideo?
+
+    @Query("DELETE FROM downloaded_videos WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    @Query("DELETE FROM downloaded_videos")
+    suspend fun clear()
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadManager.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadManager.kt
@@ -50,7 +50,8 @@ class VideoDownloadManager(
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
     private val client: OkHttpClient = OkHttpClient(),
 ) {
-    private val downloadsDir: File = File(context.applicationContext.filesDir, DIR).apply { mkdirs() }
+    private val appContext = context.applicationContext
+    private val downloadsDir: File = File(appContext.filesDir, DIR).apply { mkdirs() }
 
     /** Saved + in-flight video downloads, observed by the Downloads/Detail UI. */
     val downloads: Flow<List<DownloadedVideo>> = dao.observeAll()
@@ -96,6 +97,9 @@ class VideoDownloadManager(
         if (completedPaths.containsKey(id)) return
         synchronized(activeJobs) {
             if (activeJobs.containsKey(id)) return
+            // Foreground service for the duration: Android freezes cached processes on screen-off,
+            // which aborts these multi-minute sockets. Started here (user-triggered, app visible).
+            VideoDownloadService.start(appContext)
             activeJobs[id] = scope.launch {
                 try {
                     runCatching { performDownload(item, id) }
@@ -105,6 +109,7 @@ class VideoDownloadManager(
                     withContext(NonCancellable) { cleanupIfIncomplete(id) }
                     activeJobs.remove(id)
                     _progress.update { it - id }
+                    if (activeJobs.isEmpty()) VideoDownloadService.stop(appContext)
                 }
             }
         }
@@ -117,7 +122,7 @@ class VideoDownloadManager(
             runCatching { job.join() }
         }
         dao.findById(id)?.let { deleteQuietly(File(it.filePath)) }
-        deleteQuietly(File(downloadsDir, "$id.mp4"))
+        deleteQuietly(File(downloadsDir, "$id$FILE_EXT"))
         dao.deleteById(id)
     }
 
@@ -128,6 +133,7 @@ class VideoDownloadManager(
         }
         jobs.forEach { it.cancel() }
         jobs.forEach { runCatching { it.join() } }
+        VideoDownloadService.stop(appContext)
         _progress.value = emptyMap()
         dao.clear()
         withContext(Dispatchers.IO) {
@@ -142,8 +148,8 @@ class VideoDownloadManager(
         // Incomplete row first, so the Downloads UI lists the title while bytes stream in.
         dao.upsert(item.toDownloadedVideo(path = "", size = 0, qualityLabel = quality.label, complete = false))
         _progress.update { it + (id to VideoDownloadProgress(percent = 0, bytes = 0)) }
-        val target = File(downloadsDir, "$id.mp4")
-        val part = File(downloadsDir, "$id.mp4.part")
+        val target = File(downloadsDir, "$id$FILE_EXT")
+        val part = File(downloadsDir, "$id$FILE_EXT.part")
         val saved = streamToFile(url, part, id)
         if (saved && part.renameTo(target)) {
             dao.upsert(
@@ -177,7 +183,7 @@ class VideoDownloadManager(
     /** Delete the partial file and the incomplete row of [id]; no-op once the download completed. */
     private suspend fun cleanupIfIncomplete(id: String) {
         if (dao.findById(id)?.complete != true) {
-            deleteQuietly(File(downloadsDir, "$id.mp4.part"))
+            deleteQuietly(File(downloadsDir, "$id$FILE_EXT.part"))
             dao.deleteById(id)
         }
     }
@@ -251,6 +257,9 @@ class VideoDownloadManager(
     private companion object {
         const val TAG = "VideoDownloadManager"
         const val DIR = "video_downloads"
+
+        /** MPEG-TS: the only container the server can finalize over a non-seekable HTTP response. */
+        const val FILE_EXT = ".ts"
         const val BUFFER_BYTES = 64 * 1024
         const val PROGRESS_STEP_BYTES = 512L * 1024
         const val MIN_FREE_BYTES = 500L * 1024 * 1024

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadManager.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadManager.kt
@@ -1,0 +1,258 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.compose.ui.graphics.toArgb
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.ResponseBody
+import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
+import pe.net.libre.mixtapehaven.model.VideoItem
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.Collections
+
+/**
+ * Progress of one in-flight video download. [percent] stays 0 while the server transcodes with an
+ * unknown final size, so surface [bytes] ("142 MB so far") rather than a determinate bar.
+ */
+data class VideoDownloadProgress(val percent: Int, val bytes: Long)
+
+/**
+ * App-scoped service that saves quality-capped transcodes of movies/episodes for offline playback.
+ * Unlike the audio [DownloadManager] nothing is saved automatically: downloads are user-triggered
+ * per title via [download]. The quality cap comes from [DownloadSettingsStore.videoQuality] at
+ * download time. An incomplete row is kept while bytes stream so the UI can show in-flight state;
+ * failures and cancellations clean up both the partial file and the row.
+ */
+class VideoDownloadManager(
+    context: Context,
+    private val repository: JellyfinRepository,
+    private val dao: VideoDownloadDao,
+    private val settingsStore: DownloadSettingsStore,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    private val client: OkHttpClient = OkHttpClient(),
+) {
+    private val downloadsDir: File = File(context.applicationContext.filesDir, DIR).apply { mkdirs() }
+
+    /** Saved + in-flight video downloads, observed by the Downloads/Detail UI. */
+    val downloads: Flow<List<DownloadedVideo>> = dao.observeAll()
+
+    /** Running total of bytes used by completed video downloads. */
+    val totalSizeBytes: Flow<Long> = dao.observeTotalSize()
+
+    private val _progress = MutableStateFlow<Map<String, VideoDownloadProgress>>(emptyMap())
+
+    /** In-flight download progress keyed by item id; an id is absent once its download ends. */
+    val progress: StateFlow<Map<String, VideoDownloadProgress>> = _progress.asStateFlow()
+
+    /** Completed downloads as id -> file path, kept in memory so the resolver lookup is synchronous. */
+    @Volatile
+    private var completedPaths: Map<String, String> = emptyMap()
+
+    private val activeJobs: MutableMap<String, Job> = Collections.synchronizedMap(mutableMapOf())
+
+    init {
+        scope.launch {
+            dao.observeAll().collect { rows ->
+                completedPaths = rows.filter { it.complete }.associate { it.id to it.filePath }
+            }
+        }
+    }
+
+    /**
+     * Local playback URI for [itemId] if a completed copy exists, else null. Synchronous
+     * (in-memory lookup) so it can back [pe.net.libre.mixtapehaven.di.AppContainer.videoSourceResolver].
+     */
+    fun localUriFor(itemId: String): String? {
+        val path = completedPaths[itemId] ?: return null
+        val file = File(path)
+        return if (file.exists()) Uri.fromFile(file).toString() else null
+    }
+
+    /** Usable bytes remaining on the volume backing the download directory. */
+    fun usableSpaceBytes(): Long = downloadsDir.usableSpace
+
+    /** Start downloading [item] (a movie or episode). No-op if already saved or in flight. */
+    fun download(item: VideoItem) {
+        val id = item.id
+        if (completedPaths.containsKey(id)) return
+        synchronized(activeJobs) {
+            if (activeJobs.containsKey(id)) return
+            activeJobs[id] = scope.launch {
+                try {
+                    runCatching { performDownload(item, id) }
+                        .onFailure { Log.w(TAG, "Video download failed for $id", it) }
+                } finally {
+                    // Also runs on success, where the row is complete and the cleanup no-ops.
+                    withContext(NonCancellable) { cleanupIfIncomplete(id) }
+                    activeJobs.remove(id)
+                    _progress.update { it - id }
+                }
+            }
+        }
+    }
+
+    /** Cancel an in-flight download of [id], or delete its saved copy. */
+    suspend fun remove(id: String) {
+        activeJobs[id]?.let { job ->
+            job.cancel()
+            runCatching { job.join() }
+        }
+        dao.findById(id)?.let { deleteQuietly(File(it.filePath)) }
+        deleteQuietly(File(downloadsDir, "$id.mp4"))
+        dao.deleteById(id)
+    }
+
+    /** Cancel in-flight downloads, delete every saved video, and clear the video library. */
+    suspend fun removeAll() {
+        val jobs = synchronized(activeJobs) {
+            activeJobs.values.toList().also { activeJobs.clear() }
+        }
+        jobs.forEach { it.cancel() }
+        jobs.forEach { runCatching { it.join() } }
+        _progress.value = emptyMap()
+        dao.clear()
+        withContext(Dispatchers.IO) {
+            downloadsDir.listFiles()?.forEach { runCatching { it.delete() } }
+        }
+        completedPaths = emptyMap()
+    }
+
+    private suspend fun performDownload(item: VideoItem, id: String) {
+        val quality = settingsStore.videoQuality.first()
+        val url = transcodeUrlOrNull(id, quality) ?: return
+        // Incomplete row first, so the Downloads UI lists the title while bytes stream in.
+        dao.upsert(item.toDownloadedVideo(path = "", size = 0, qualityLabel = quality.label, complete = false))
+        _progress.update { it + (id to VideoDownloadProgress(percent = 0, bytes = 0)) }
+        val target = File(downloadsDir, "$id.mp4")
+        val part = File(downloadsDir, "$id.mp4.part")
+        val saved = streamToFile(url, part, id)
+        if (saved && part.renameTo(target)) {
+            dao.upsert(
+                item.toDownloadedVideo(
+                    path = target.path,
+                    size = target.length(),
+                    qualityLabel = quality.label,
+                    complete = true,
+                ),
+            )
+        }
+    }
+
+    /** The transcode URL to download for [id], or null if it is already saved or storage is low. */
+    private suspend fun transcodeUrlOrNull(id: String, quality: VideoDownloadQuality): String? {
+        val alreadySaved = dao.findById(id)?.complete == true
+        val lowStorage = !shouldStartDownload(usableSpaceBytes(), MIN_FREE_BYTES)
+        if (lowStorage) Log.w(TAG, "Skipping video download of $id: storage low")
+        return if (alreadySaved || lowStorage) {
+            null
+        } else {
+            repository.videoDownloadUrl(
+                itemId = id,
+                maxHeight = quality.maxHeight,
+                videoBitRate = quality.videoBitRate,
+                audioBitRate = quality.audioBitRate,
+            )
+        }
+    }
+
+    /** Delete the partial file and the incomplete row of [id]; no-op once the download completed. */
+    private suspend fun cleanupIfIncomplete(id: String) {
+        if (dao.findById(id)?.complete != true) {
+            deleteQuietly(File(downloadsDir, "$id.mp4.part"))
+            dao.deleteById(id)
+        }
+    }
+
+    /** Stream [url] into [part], emitting progress for [id]. Returns false if cancelled or on HTTP error. */
+    private suspend fun streamToFile(url: String, part: File, id: String): Boolean {
+        val request = Request.Builder().url(url).build()
+        return client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                Log.w(TAG, "Video download of $id got HTTP ${response.code}")
+                false
+            } else {
+                copyBody(response.body, part, id)
+            }
+        }
+    }
+
+    /** Copy [body] to [part], emitting progress for [id]. Returns false if cancelled mid-stream. */
+    private suspend fun copyBody(body: ResponseBody, part: File, id: String): Boolean =
+        part.outputStream().use { output ->
+            body.byteStream().use { input -> pumpStream(input, output, body.contentLength(), id) }
+        }
+
+    /** Pump [input] to [output] in chunks, emitting progress. False if cancelled before completion. */
+    private suspend fun pumpStream(input: InputStream, output: OutputStream, total: Long, id: String): Boolean {
+        val buffer = ByteArray(BUFFER_BYTES)
+        var downloaded = 0L
+        while (currentCoroutineContext().isActive) {
+            val read = input.read(buffer)
+            if (read < 0) return true
+            output.write(buffer, 0, read)
+            downloaded += read
+            emitProgress(id, downloaded, total)
+        }
+        return false
+    }
+
+    /** Publish progress when the percent changes or another [PROGRESS_STEP_BYTES] have arrived. */
+    private fun emitProgress(id: String, downloaded: Long, total: Long) {
+        val previous = _progress.value[id]
+        val percent = percentOf(downloaded, total)
+        if (previous == null || percent != previous.percent || downloaded - previous.bytes >= PROGRESS_STEP_BYTES) {
+            _progress.update { it + (id to VideoDownloadProgress(percent, downloaded)) }
+        }
+    }
+
+    private fun deleteQuietly(file: File) {
+        if (file.exists() && !file.delete()) Log.w(TAG, "Could not delete ${file.name}")
+    }
+
+    private fun VideoItem.toDownloadedVideo(
+        path: String,
+        size: Long,
+        qualityLabel: String,
+        complete: Boolean,
+    ) = DownloadedVideo(
+        id = id,
+        title = title,
+        kind = kind.name,
+        seriesName = seriesName,
+        seasonEpisodeLabel = seasonEpisodeLabel,
+        runtimeLabel = runtimeLabel,
+        posterUrl = posterUrl,
+        artColorArgb = artColor.toArgb(),
+        qualityLabel = qualityLabel,
+        filePath = path,
+        sizeBytes = size,
+        complete = complete,
+    )
+
+    private companion object {
+        const val TAG = "VideoDownloadManager"
+        const val DIR = "video_downloads"
+        const val BUFFER_BYTES = 64 * 1024
+        const val PROGRESS_STEP_BYTES = 512L * 1024
+        const val MIN_FREE_BYTES = 500L * 1024 * 1024
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadManager.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import androidx.compose.ui.graphics.toArgb
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -11,8 +12,11 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -64,6 +68,11 @@ class VideoDownloadManager(
     /** In-flight download progress keyed by item id; an id is absent once its download ends. */
     val progress: StateFlow<Map<String, VideoDownloadProgress>> = _progress.asStateFlow()
 
+    private val _errors = MutableSharedFlow<String>(extraBufferCapacity = ERROR_BUFFER)
+
+    /** One human-readable message per failed download, for the UI to toast/snackbar. */
+    val errors: SharedFlow<String> = _errors.asSharedFlow()
+
     /** Completed downloads as id -> file path, kept in memory so the resolver lookup is synchronous. */
     @Volatile
     private var completedPaths: Map<String, String> = emptyMap()
@@ -103,13 +112,25 @@ class VideoDownloadManager(
             activeJobs[id] = scope.launch {
                 try {
                     runCatching { performDownload(item, id) }
-                        .onFailure { Log.w(TAG, "Video download failed for $id", it) }
+                        .onFailure { failure ->
+                            Log.w(TAG, "Video download failed for $id", failure)
+                            // A cancellation is the user's own doing; everything else deserves a
+                            // message. OkHttp surfaces our call.cancel() as an IOException, so also
+                            // check whether this job was cancelled rather than genuinely failing.
+                            val cancelled =
+                                failure is CancellationException || !currentCoroutineContext().isActive
+                            if (!cancelled) _errors.tryEmit("Download failed for ${item.title}")
+                        }
                 } finally {
                     // Also runs on success, where the row is complete and the cleanup no-ops.
                     withContext(NonCancellable) { cleanupIfIncomplete(id) }
-                    activeJobs.remove(id)
+                    // Same lock as start(): otherwise a finishing job can see the map momentarily
+                    // empty and stop the service right after a new download started it.
+                    synchronized(activeJobs) {
+                        activeJobs.remove(id)
+                        if (activeJobs.isEmpty()) VideoDownloadService.stop(appContext)
+                    }
                     _progress.update { it - id }
-                    if (activeJobs.isEmpty()) VideoDownloadService.stop(appContext)
                 }
             }
         }
@@ -163,21 +184,26 @@ class VideoDownloadManager(
         }
     }
 
-    /** The transcode URL to download for [id], or null if it is already saved or storage is low. */
+    /**
+     * The transcode URL to download for [id], or null if the download cannot start. Emits the
+     * reason on [errors] for every null except "already saved" (a silent no-op for the user).
+     */
     private suspend fun transcodeUrlOrNull(id: String, quality: VideoDownloadQuality): String? {
         val alreadySaved = dao.findById(id)?.complete == true
         val lowStorage = !shouldStartDownload(usableSpaceBytes(), MIN_FREE_BYTES)
-        if (lowStorage) Log.w(TAG, "Skipping video download of $id: storage low")
-        return if (alreadySaved || lowStorage) {
-            null
-        } else {
-            repository.videoDownloadUrl(
-                itemId = id,
-                maxHeight = quality.maxHeight,
-                videoBitRate = quality.videoBitRate,
-                audioBitRate = quality.audioBitRate,
-            )
+        if (lowStorage) {
+            Log.w(TAG, "Skipping video download of $id: storage low")
+            _errors.tryEmit("Not enough free space to download")
         }
+        if (alreadySaved || lowStorage) return null
+        val url = repository.videoDownloadUrl(
+            itemId = id,
+            maxHeight = quality.maxHeight,
+            videoBitRate = quality.videoBitRate,
+            audioBitRate = quality.audioBitRate,
+        )
+        if (url == null) _errors.tryEmit("Download unavailable — check your connection")
+        return url
     }
 
     /** Delete the partial file and the incomplete row of [id]; no-op once the download completed. */
@@ -190,14 +216,22 @@ class VideoDownloadManager(
 
     /** Stream [url] into [part], emitting progress for [id]. Returns false if cancelled or on HTTP error. */
     private suspend fun streamToFile(url: String, part: File, id: String): Boolean {
-        val request = Request.Builder().url(url).build()
-        return client.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                Log.w(TAG, "Video download of $id got HTTP ${response.code}")
-                false
-            } else {
-                copyBody(response.body, part, id)
+        val call = client.newCall(Request.Builder().url(url).build())
+        // Blocking OkHttp I/O ignores coroutine cancellation; without this the socket keeps
+        // pulling the transcode until it times out after the user cancels.
+        val onCancel = currentCoroutineContext()[Job]?.invokeOnCompletion { call.cancel() }
+        return try {
+            call.execute().use { response ->
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "Video download of $id got HTTP ${response.code}")
+                    _errors.tryEmit("Download failed (server error ${response.code})")
+                    false
+                } else {
+                    copyBody(response.body, part, id)
+                }
             }
+        } finally {
+            onCancel?.dispose()
         }
     }
 
@@ -263,5 +297,6 @@ class VideoDownloadManager(
         const val BUFFER_BYTES = 64 * 1024
         const val PROGRESS_STEP_BYTES = 512L * 1024
         const val MIN_FREE_BYTES = 500L * 1024 * 1024
+        const val ERROR_BUFFER = 4
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadQuality.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadQuality.kt
@@ -1,0 +1,25 @@
+package pe.net.libre.mixtapehaven.data.download
+
+/**
+ * Quality cap applied to video downloads. Videos are transcoded server-side to h264/aac mp4
+ * within these limits, so a phone-sized copy is saved instead of the (often huge) original.
+ */
+enum class VideoDownloadQuality(
+    val label: String,
+    val maxHeight: Int,
+    val videoBitRate: Int,
+    val audioBitRate: Int,
+) {
+    HD_1080("1080p", 1080, 10_000_000, 384_000),
+    HD_720("720p", 720, 4_000_000, 256_000),
+    SD_480("480p", 480, 1_500_000, 128_000),
+    ;
+
+    companion object {
+        val DEFAULT = HD_720
+
+        /** The quality persisted under [name], falling back to [DEFAULT] for unknown/absent values. */
+        fun fromName(name: String?): VideoDownloadQuality =
+            entries.firstOrNull { it.name == name } ?: DEFAULT
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadService.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadService.kt
@@ -1,0 +1,56 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import pe.net.libre.mixtapehaven.R
+
+/**
+ * Minimal dataSync foreground service held open while video downloads run. Without it Android
+ * freezes the app process shortly after the screen turns off, aborting the sockets of these
+ * multi-minute transfers ("Software caused connection abort"). The service carries no logic of
+ * its own: [VideoDownloadManager] starts it with the first active download and stops it with the
+ * last, and the mandatory notification is the user's cue that a download is still running.
+ */
+class VideoDownloadService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        createChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
+        return START_NOT_STICKY
+    }
+
+    private fun createChannel() {
+        getSystemService(NotificationManager::class.java).createNotificationChannel(
+            NotificationChannel(CHANNEL_ID, "Video downloads", NotificationManager.IMPORTANCE_LOW),
+        )
+    }
+
+    private fun buildNotification(): Notification =
+        Notification.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("Downloading video")
+            .setContentText("Saving for offline playback")
+            .setOngoing(true)
+            .build()
+
+    companion object {
+        private const val CHANNEL_ID = "video_downloads"
+        private const val NOTIFICATION_ID = 20
+
+        /** Promote the app to a foreground data-sync service while downloads are active. */
+        fun start(context: Context) {
+            context.startForegroundService(Intent(context, VideoDownloadService::class.java))
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, VideoDownloadService::class.java))
+        }
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadService.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.IBinder
 import pe.net.libre.mixtapehaven.R
 
@@ -20,11 +21,17 @@ class VideoDownloadService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? = null
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    // In onCreate, not onStartCommand: the system requires startForeground() within ~5s of
+    // startForegroundService(), and a download that fails instantly can issue stop() before
+    // onStartCommand ever runs. onCreate fires on instantiation, shrinking that window to zero.
+    // The explicit type is mandatory on API 34+ when the manifest declares one.
+    override fun onCreate() {
+        super.onCreate()
         createChannel()
-        startForeground(NOTIFICATION_ID, buildNotification())
-        return START_NOT_STICKY
+        startForeground(NOTIFICATION_ID, buildNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
     }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_NOT_STICKY
 
     private fun createChannel() {
         getSystemService(NotificationManager::class.java).createNotificationChannel(

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinAudioMapping.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinAudioMapping.kt
@@ -1,0 +1,70 @@
+package pe.net.libre.mixtapehaven.data.jellyfin
+
+import androidx.compose.ui.graphics.Color
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.imageApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.ImageType
+import pe.net.libre.mixtapehaven.model.Album
+import pe.net.libre.mixtapehaven.model.Track
+
+/** Mapping from Jellyfin DTOs to the audio domain model, kept out of [JellyfinRepository] for size. */
+
+private const val TICKS_PER_SECOND = 10_000_000L
+
+internal fun BaseItemDto.toAlbum(client: ApiClient): Album = Album(
+    id = id.toString(),
+    title = name ?: "Unknown album",
+    artist = albumArtist ?: artists?.firstOrNull() ?: "Unknown artist",
+    artColor = audioColorFor(id.toString()),
+    imageUrl = primaryImageUrl(client),
+    downloaded = false,
+)
+
+internal fun BaseItemDto.toTrack(client: ApiClient): Track = Track(
+    id = id.toString(),
+    title = name ?: "Unknown track",
+    artist = artists?.joinToString(", ").orEmpty().ifEmpty { albumArtist ?: "Unknown artist" },
+    durationLabel = formatDuration(runTimeTicks),
+    artColor = audioColorFor(id.toString()),
+    imageUrl = primaryImageUrl(client),
+)
+
+private fun BaseItemDto.primaryImageUrl(client: ApiClient): String? {
+    val ownTag = imageTags?.get(ImageType.PRIMARY)
+    return when {
+        ownTag != null ->
+            client.imageApi.getItemImageUrl(id, ImageType.PRIMARY, tag = ownTag, maxWidth = IMAGE_MAX_WIDTH)
+                .withApiKey(client)
+
+        albumId != null && albumPrimaryImageTag != null ->
+            client.imageApi.getItemImageUrl(
+                albumId!!,
+                ImageType.PRIMARY,
+                tag = albumPrimaryImageTag,
+                maxWidth = IMAGE_MAX_WIDTH,
+            ).withApiKey(client)
+
+        else -> null
+    }
+}
+
+private val AUDIO_PALETTE = listOf(
+    Color(0xFFC65B4E),
+    Color(0xFF9A8A3C),
+    Color(0xFFA86B7E),
+    Color(0xFFB5633B),
+    Color(0xFFB59A4E),
+    Color(0xFF6C8A7A),
+)
+
+private fun audioColorFor(key: String): Color =
+    AUDIO_PALETTE[(key.hashCode() and Int.MAX_VALUE) % AUDIO_PALETTE.size]
+
+private fun formatDuration(ticks: Long?): String {
+    if (ticks == null || ticks <= 0) return "--:--"
+    val totalSeconds = ticks / TICKS_PER_SECOND
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return "%d:%02d".format(minutes, seconds)
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
@@ -1,6 +1,5 @@
 package pe.net.libre.mixtapehaven.data.jellyfin
 
-import androidx.compose.ui.graphics.Color
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import org.jellyfin.sdk.Jellyfin
@@ -8,16 +7,14 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.audioApi
 import org.jellyfin.sdk.api.client.extensions.authenticateUserByName
 import org.jellyfin.sdk.api.client.extensions.dynamicHlsApi
-import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.api.client.extensions.playStateApi
 import org.jellyfin.sdk.api.client.extensions.tvShowsApi
 import org.jellyfin.sdk.api.client.extensions.userApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
-import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ImageType
+import org.jellyfin.sdk.model.api.EncodingContext
 import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.PlayMethod
@@ -252,67 +249,31 @@ class JellyfinRepository(
         }
     }
 
+    /**
+     * URL of a server-side transcode of [itemId] capped at [maxHeight]/[videoBitRate]/[audioBitRate]
+     * (h264/aac mp4), for saving a phone-sized offline copy instead of the original file.
+     */
+    fun videoDownloadUrl(itemId: String, maxHeight: Int, videoBitRate: Int, audioBitRate: Int): String? {
+        val client = api
+        val id = runCatching { UUID.fromString(itemId) }.getOrNull()
+        if (client == null || id == null) return null
+        return client.videosApi
+            .getVideoStreamUrl(
+                itemId = id,
+                container = "mp4",
+                static = false,
+                // The server requires a media source; the default source id is the item id unhyphenated.
+                mediaSourceId = itemId.replace("-", ""),
+                videoCodec = "h264",
+                audioCodec = "aac",
+                maxHeight = maxHeight,
+                videoBitRate = videoBitRate,
+                audioBitRate = audioBitRate,
+                context = EncodingContext.STATIC,
+            )
+            .withApiKey(client)
+    }
+
     private fun requireApi(): ApiClient =
         api ?: error("Not authenticated with a Jellyfin server")
-
-    private fun BaseItemDto.toAlbum(client: ApiClient): Album = Album(
-        id = id.toString(),
-        title = name ?: "Unknown album",
-        artist = albumArtist ?: artists?.firstOrNull() ?: "Unknown artist",
-        artColor = colorFor(id.toString()),
-        imageUrl = primaryImageUrl(client),
-        downloaded = false,
-    )
-
-    private fun BaseItemDto.toTrack(client: ApiClient): Track = Track(
-        id = id.toString(),
-        title = name ?: "Unknown track",
-        artist = artists?.joinToString(", ").orEmpty().ifEmpty { albumArtist ?: "Unknown artist" },
-        durationLabel = formatDuration(runTimeTicks),
-        artColor = colorFor(id.toString()),
-        imageUrl = primaryImageUrl(client),
-    )
-
-    private fun BaseItemDto.primaryImageUrl(client: ApiClient): String? {
-        val ownTag = imageTags?.get(ImageType.PRIMARY)
-        return when {
-            ownTag != null ->
-                client.imageApi.getItemImageUrl(id, ImageType.PRIMARY, tag = ownTag, maxWidth = IMAGE_MAX_WIDTH)
-                    .withApiKey(client)
-
-            albumId != null && albumPrimaryImageTag != null ->
-                client.imageApi.getItemImageUrl(
-                    albumId!!,
-                    ImageType.PRIMARY,
-                    tag = albumPrimaryImageTag,
-                    maxWidth = IMAGE_MAX_WIDTH,
-                ).withApiKey(client)
-
-            else -> null
-        }
-    }
-
-    private companion object {
-        const val TICKS_PER_SECOND = 10_000_000L
-
-        val PALETTE = listOf(
-            Color(0xFFC65B4E),
-            Color(0xFF9A8A3C),
-            Color(0xFFA86B7E),
-            Color(0xFFB5633B),
-            Color(0xFFB59A4E),
-            Color(0xFF6C8A7A),
-        )
-
-        fun colorFor(key: String): Color =
-            PALETTE[(key.hashCode() and Int.MAX_VALUE) % PALETTE.size]
-
-        fun formatDuration(ticks: Long?): String {
-            if (ticks == null || ticks <= 0) return "--:--"
-            val totalSeconds = ticks / TICKS_PER_SECOND
-            val minutes = totalSeconds / 60
-            val seconds = totalSeconds % 60
-            return "%d:%02d".format(minutes, seconds)
-        }
-    }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
@@ -200,7 +200,7 @@ class JellyfinRepository(
         val hls = client.dynamicHlsApi
             .getMasterHlsVideoPlaylistUrl(
                 itemId = id,
-                // The server requires a media source; the default source id is the item id unhyphenated.
+                // Known limitation: assumes the default single media source (see videoDownloadUrl).
                 mediaSourceId = itemId.replace("-", ""),
                 videoCodec = "h264",
                 audioCodec = "aac",
@@ -266,7 +266,10 @@ class JellyfinRepository(
                 itemId = id,
                 container = "ts",
                 static = false,
-                // The server requires a media source; the default source id is the item id unhyphenated.
+                // Known limitation: the default source id is the item id unhyphenated, which holds
+                // for plain single-file library items but not for multi-version or .strm-backed
+                // ones. The robust path is mediaInfoApi.getPostedPlaybackInfo and using
+                // mediaSources.first().id, as full clients do.
                 mediaSourceId = itemId.replace("-", ""),
                 videoCodec = "h264",
                 audioCodec = "aac",

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
@@ -251,7 +251,11 @@ class JellyfinRepository(
 
     /**
      * URL of a server-side transcode of [itemId] capped at [maxHeight]/[videoBitRate]/[audioBitRate]
-     * (h264/aac mp4), for saving a phone-sized offline copy instead of the original file.
+     * (h264/aac), for saving a phone-sized offline copy instead of the original file.
+     *
+     * The container is MPEG-TS, not mp4: ffmpeg muxing mp4 over a non-seekable HTTP response can
+     * never backpatch the mdat size, so the moov index at the tail is unreachable and ExoPlayer
+     * rejects the saved file as malformed. TS needs no finalization and stays seekable.
      */
     fun videoDownloadUrl(itemId: String, maxHeight: Int, videoBitRate: Int, audioBitRate: Int): String? {
         val client = api
@@ -260,7 +264,7 @@ class JellyfinRepository(
         return client.videosApi
             .getVideoStreamUrl(
                 itemId = id,
-                container = "mp4",
+                container = "ts",
                 static = false,
                 // The server requires a media source; the default source id is the item id unhyphenated.
                 mediaSourceId = itemId.replace("-", ""),

--- a/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
@@ -7,6 +7,7 @@ import org.jellyfin.sdk.model.ClientInfo
 import pe.net.libre.mixtapehaven.data.download.DownloadDatabase
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.download.DownloadSettingsStore
+import pe.net.libre.mixtapehaven.data.download.VideoDownloadManager
 import pe.net.libre.mixtapehaven.data.download.resolveLocalFirst
 import pe.net.libre.mixtapehaven.data.diagnostics.DiagnosticsLog
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
@@ -52,6 +53,15 @@ class AppContainer(context: Context) {
         )
     }
 
+    val videoDownloadManager: VideoDownloadManager by lazy {
+        VideoDownloadManager(
+            context = appContext,
+            repository = repository,
+            dao = downloadDatabase.videoDownloadDao(),
+            settingsStore = downloadSettingsStore,
+        )
+    }
+
     init {
         // Wire the two app-scoped singletons after both are built, so neither depends on the other
         // at construction time. Eager so auto-download runs before any download UI is opened.
@@ -62,5 +72,12 @@ class AppContainer(context: Context) {
             resolveLocalFirst(track, manager::localUriFor, repository::audioStreamUrl)
         }
         manager.start(controller.nowPlaying)
+        // Same local-first idea for video: a saved copy is the only candidate (no network fallback
+        // mid-list — if the file plays, remote candidates are never needed; if it's gone the
+        // resolver won't have listed it since localUriFor checks existence).
+        val videoManager = videoDownloadManager
+        videoSourceResolver = { itemId ->
+            videoManager.localUriFor(itemId)?.let { listOf(it) } ?: repository.videoStreamCandidates(itemId)
+        }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
@@ -72,7 +72,10 @@ fun MixtapeNavHost(startDestination: String, modifier: Modifier = Modifier) {
             )
         }
         composable(Routes.DOWNLOADS) {
-            DownloadsScreen(onBack = { navController.popBackStack() })
+            DownloadsScreen(
+                onBack = { navController.popBackStack() },
+                onPlayVideo = { itemId -> navController.navigate(Routes.videoPlayer(itemId)) },
+            )
         }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsScreen.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import pe.net.libre.mixtapehaven.data.download.DownloadProgress
 import pe.net.libre.mixtapehaven.di.appViewModel
+import pe.net.libre.mixtapehaven.model.Track
 import pe.net.libre.mixtapehaven.ui.components.Artwork
 import pe.net.libre.mixtapehaven.ui.components.BackTopBar
 import pe.net.libre.mixtapehaven.ui.components.SectionLabel
@@ -49,7 +51,11 @@ import pe.net.libre.mixtapehaven.ui.theme.TextSecondary
 private val VideoLegend = Color(0xFF7BB661)
 
 @Composable
-fun DownloadsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
+fun DownloadsScreen(
+    onBack: () -> Unit,
+    onPlayVideo: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val viewModel = appViewModel { DownloadsViewModel(it.downloadManager, it.videoDownloadManager) }
     val state by viewModel.state.collectAsState()
 
@@ -65,83 +71,11 @@ fun DownloadsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
     ) {
         BackTopBar(title = "Downloads", onBack = onBack)
 
-        // Storage summary block
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text("Mixtape downloads", style = MaterialTheme.typography.titleMedium, color = TextPrimary)
-                Text(state.totalLabel, style = MaterialTheme.typography.titleMedium, color = TextSecondary)
-            }
-            StorageBar(segments = listOf(state.audioFraction to Accent, state.videoFraction to VideoLegend))
-            LegendItem(Accent, "Music, saved as you listen · ${state.audioTotalLabel}")
-            LegendItem(VideoLegend, "Movies & shows · ${state.videoTotalLabel}")
-        }
+        StorageSummary(state)
 
-        val downloading = state.downloading
-        if (downloading != null) {
-            SectionLabel("DOWNLOADING")
-            TrackRow(
-                track = downloading.track,
-                trailing = {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Text(
-                            "${downloading.percent}%",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = Accent,
-                        )
-                        CircularProgressIndicator(
-                            progress = { downloading.percent / 100f },
-                            color = Accent,
-                            trackColor = Surface2,
-                            modifier = Modifier.size(18.dp),
-                            strokeWidth = 2.dp,
-                        )
-                    }
-                },
-            )
-        }
+        state.downloading?.let { AudioDownloadingSection(it) }
 
-        SectionLabel("SAVED ON DEVICE")
-
-        if (state.saved.isEmpty()) {
-            Text(
-                "Nothing saved yet. Play anything and it's kept for offline automatically.",
-                style = MaterialTheme.typography.bodySmall,
-                color = TextMuted,
-            )
-        } else {
-            Column {
-                state.saved.forEach { track ->
-                    TrackRow(
-                        track = track,
-                        trailing = {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            ) {
-                                Text(
-                                    track.sizeLabel,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = TextMuted,
-                                )
-                                Icon(
-                                    Icons.Outlined.ArrowDownward,
-                                    contentDescription = "Saved offline",
-                                    tint = Accent,
-                                    modifier = Modifier.size(18.dp),
-                                )
-                            }
-                        },
-                    )
-                }
-            }
-        }
+        SavedTracksSection(state.saved)
 
         if (state.videos.isNotEmpty()) {
             SectionLabel("MOVIES & SHOWS")
@@ -149,6 +83,7 @@ fun DownloadsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 state.videos.forEach { video ->
                     SavedVideoRow(
                         video = video,
+                        onPlay = { onPlayVideo(video.id) },
                         onRemove = { viewModel.removeVideo(video.id) },
                     )
                 }
@@ -184,11 +119,103 @@ fun DownloadsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
     }
 }
 
-/** One saved (or still-downloading) video: poster thumb, title/meta, and cancel/delete control. */
+/** Combined storage bar (music + video segments) with total and per-type legends. */
 @Composable
-private fun SavedVideoRow(video: SavedVideoUi, onRemove: () -> Unit) {
+private fun StorageSummary(state: DownloadsViewModel.UiState) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("Mixtape downloads", style = MaterialTheme.typography.titleMedium, color = TextPrimary)
+            Text(state.totalLabel, style = MaterialTheme.typography.titleMedium, color = TextSecondary)
+        }
+        StorageBar(segments = listOf(state.audioFraction to Accent, state.videoFraction to VideoLegend))
+        LegendItem(Accent, "Music, saved as you listen · ${state.audioTotalLabel}")
+        LegendItem(VideoLegend, "Movies & shows · ${state.videoTotalLabel}")
+    }
+}
+
+/** The one audio track currently being auto-saved, with its live percent. */
+@Composable
+private fun AudioDownloadingSection(downloading: DownloadProgress) {
+    SectionLabel("DOWNLOADING")
+    TrackRow(
+        track = downloading.track,
+        trailing = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    "${downloading.percent}%",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Accent,
+                )
+                CircularProgressIndicator(
+                    progress = { downloading.percent / 100f },
+                    color = Accent,
+                    trackColor = Surface2,
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                )
+            }
+        },
+    )
+}
+
+/** The saved audio library, or the how-it-works hint while it is still empty. */
+@Composable
+private fun SavedTracksSection(saved: List<Track>) {
+    SectionLabel("SAVED ON DEVICE")
+    if (saved.isEmpty()) {
+        Text(
+            "Nothing saved yet. Play anything and it's kept for offline automatically.",
+            style = MaterialTheme.typography.bodySmall,
+            color = TextMuted,
+        )
+    } else {
+        Column {
+            saved.forEach { track ->
+                TrackRow(
+                    track = track,
+                    trailing = {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                track.sizeLabel,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = TextMuted,
+                            )
+                            Icon(
+                                Icons.Outlined.ArrowDownward,
+                                contentDescription = "Saved offline",
+                                tint = Accent,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * One saved (or still-downloading) video: poster thumb, title/meta, and cancel/delete control.
+ * Tapping a completed row plays it — the only path to downloaded videos when offline, where the
+ * server-backed Home rail and detail screen are unavailable.
+ */
+@Composable
+private fun SavedVideoRow(video: SavedVideoUi, onPlay: () -> Unit, onRemove: () -> Unit) {
     Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !video.downloading, onClick = onPlay)
+            .padding(vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsScreen.kt
@@ -30,8 +30,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import pe.net.libre.mixtapehaven.di.appViewModel
+import pe.net.libre.mixtapehaven.ui.components.Artwork
 import pe.net.libre.mixtapehaven.ui.components.BackTopBar
 import pe.net.libre.mixtapehaven.ui.components.SectionLabel
 import pe.net.libre.mixtapehaven.ui.components.StorageBar
@@ -43,9 +45,12 @@ import pe.net.libre.mixtapehaven.ui.theme.TextMuted
 import pe.net.libre.mixtapehaven.ui.theme.TextPrimary
 import pe.net.libre.mixtapehaven.ui.theme.TextSecondary
 
+/** Legend/progress color for the video segment of the storage bar (matches the Online pill green). */
+private val VideoLegend = Color(0xFF7BB661)
+
 @Composable
 fun DownloadsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
-    val viewModel = appViewModel { DownloadsViewModel(it.downloadManager) }
+    val viewModel = appViewModel { DownloadsViewModel(it.downloadManager, it.videoDownloadManager) }
     val state by viewModel.state.collectAsState()
 
     Column(
@@ -70,8 +75,9 @@ fun DownloadsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 Text("Mixtape downloads", style = MaterialTheme.typography.titleMedium, color = TextPrimary)
                 Text(state.totalLabel, style = MaterialTheme.typography.titleMedium, color = TextSecondary)
             }
-            StorageBar(segments = listOf(state.usedFraction to Accent))
-            LegendItem(Accent, "Saved as you listen · ${state.totalLabel}")
+            StorageBar(segments = listOf(state.audioFraction to Accent, state.videoFraction to VideoLegend))
+            LegendItem(Accent, "Music, saved as you listen · ${state.audioTotalLabel}")
+            LegendItem(VideoLegend, "Movies & shows · ${state.videoTotalLabel}")
         }
 
         val downloading = state.downloading
@@ -137,8 +143,20 @@ fun DownloadsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
             }
         }
 
+        if (state.videos.isNotEmpty()) {
+            SectionLabel("MOVIES & SHOWS")
+            Column {
+                state.videos.forEach { video ->
+                    SavedVideoRow(
+                        video = video,
+                        onRemove = { viewModel.removeVideo(video.id) },
+                    )
+                }
+            }
+        }
+
         // Destructive: remove all downloads
-        if (state.saved.isNotEmpty() || state.downloading != null) {
+        if (state.saved.isNotEmpty() || state.downloading != null || state.videos.isNotEmpty()) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -163,6 +181,52 @@ fun DownloadsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 )
             }
         }
+    }
+}
+
+/** One saved (or still-downloading) video: poster thumb, title/meta, and cancel/delete control. */
+@Composable
+private fun SavedVideoRow(video: SavedVideoUi, onRemove: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Artwork(
+            color = video.artColor,
+            imageUrl = video.posterUrl,
+            modifier = Modifier.size(44.dp),
+            corner = 8.dp,
+        )
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                video.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = TextPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            val meta = listOf(video.subtitle, video.sizeLabel).filter { it.isNotEmpty() }.joinToString(" · ")
+            Text(meta, style = MaterialTheme.typography.bodySmall, color = TextMuted)
+        }
+        if (video.downloading) {
+            CircularProgressIndicator(
+                color = VideoLegend,
+                trackColor = Surface2,
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        Icon(
+            Icons.Outlined.DeleteOutline,
+            contentDescription = if (video.downloading) "Cancel download" else "Remove download",
+            tint = TextSecondary,
+            modifier = Modifier
+                .size(34.dp)
+                .clip(CircleShape)
+                .clickable(onClick = onRemove)
+                .padding(7.dp),
+        )
     }
 }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/downloads/DownloadsViewModel.kt
@@ -1,5 +1,6 @@
 package pe.net.libre.mixtapehaven.ui.screens.downloads
 
+import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
@@ -11,45 +12,104 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.download.DownloadProgress
+import pe.net.libre.mixtapehaven.data.download.DownloadedTrack
+import pe.net.libre.mixtapehaven.data.download.DownloadedVideo
+import pe.net.libre.mixtapehaven.data.download.VideoDownloadManager
+import pe.net.libre.mixtapehaven.data.download.VideoDownloadProgress
 import pe.net.libre.mixtapehaven.data.download.formatBytes
 import pe.net.libre.mixtapehaven.data.download.toTrack
 import pe.net.libre.mixtapehaven.model.Track
 
-/** Backs the Downloads screen with the real saved library, in-flight progress, and storage totals. */
+/** One saved or in-flight video download rendered on the Downloads screen. */
+data class SavedVideoUi(
+    val id: String,
+    val title: String,
+    val subtitle: String,
+    val sizeLabel: String,
+    val posterUrl: String?,
+    val artColor: Color,
+    val downloading: Boolean,
+)
+
+/** Backs the Downloads screen with the saved audio + video libraries, progress, and storage totals. */
 class DownloadsViewModel(
     private val downloadManager: DownloadManager,
+    private val videoDownloadManager: VideoDownloadManager,
 ) : ViewModel() {
 
     data class UiState(
         val downloading: DownloadProgress? = null,
         val saved: List<Track> = emptyList(),
+        val videos: List<SavedVideoUi> = emptyList(),
         val totalLabel: String = formatBytes(0),
-        val usedFraction: Float = 0f,
+        val audioTotalLabel: String = formatBytes(0),
+        val videoTotalLabel: String = formatBytes(0),
+        val audioFraction: Float = 0f,
+        val videoFraction: Float = 0f,
     )
 
     val state: StateFlow<UiState> =
-        combine(downloadManager.downloads, downloadManager.progress) { rows, progress ->
+        combine(
+            downloadManager.downloads,
+            downloadManager.progress,
+            videoDownloadManager.downloads,
+            videoDownloadManager.progress,
+        ) { rows, progress, videoRows, videoProgress ->
             // Mapping + File.usableSpace touch disk; keep them off the Main thread.
             withContext(Dispatchers.IO) {
-                val completed = rows.filter { it.complete }
-                val totalBytes = completed.sumOf { it.sizeBytes }
-                UiState(
-                    downloading = progress,
-                    saved = completed.map { it.toTrack() },
-                    totalLabel = formatBytes(totalBytes),
-                    usedFraction = usedFractionOf(totalBytes, downloadManager.usableSpaceBytes()),
-                )
+                buildState(rows.filter { it.complete }, progress, videoRows, videoProgress)
             }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), UiState())
 
+    private fun buildState(
+        completedTracks: List<DownloadedTrack>,
+        progress: DownloadProgress?,
+        videoRows: List<DownloadedVideo>,
+        videoProgress: Map<String, VideoDownloadProgress>,
+    ): UiState {
+        val audioBytes = completedTracks.sumOf { it.sizeBytes }
+        val videoBytes = videoRows.filter { it.complete }.sumOf { it.sizeBytes }
+        val free = videoDownloadManager.usableSpaceBytes()
+        return UiState(
+            downloading = progress,
+            saved = completedTracks.map { it.toTrack() },
+            videos = videoRows.map { it.toSavedVideoUi(videoProgress) },
+            totalLabel = formatBytes(audioBytes + videoBytes),
+            audioTotalLabel = formatBytes(audioBytes),
+            videoTotalLabel = formatBytes(videoBytes),
+            audioFraction = usedFractionOf(audioBytes, videoBytes + free),
+            videoFraction = usedFractionOf(videoBytes, audioBytes + free),
+        )
+    }
+
+    /** Cancels an in-flight video download or deletes the saved copy. */
+    fun removeVideo(id: String) {
+        viewModelScope.launch { videoDownloadManager.remove(id) }
+    }
+
     fun removeAll() {
-        viewModelScope.launch { downloadManager.removeAll() }
+        viewModelScope.launch {
+            downloadManager.removeAll()
+            videoDownloadManager.removeAll()
+        }
     }
 
     private companion object {
         const val STOP_TIMEOUT_MS = 5_000L
     }
 }
+
+/** Map a download row to its screen representation; in-flight rows show streamed bytes so far. */
+private fun DownloadedVideo.toSavedVideoUi(progress: Map<String, VideoDownloadProgress>): SavedVideoUi =
+    SavedVideoUi(
+        id = id,
+        title = title,
+        subtitle = listOfNotNull(seriesName, seasonEpisodeLabel, qualityLabel).joinToString(" · "),
+        sizeLabel = if (complete) formatBytes(sizeBytes) else formatBytes(progress[id]?.bytes ?: 0),
+        posterUrl = posterUrl,
+        artColor = Color(artColorArgb),
+        downloading = !complete,
+    )
 
 /** Fraction of the storage bar to fill: used bytes over (used + free), clamped to a sane minimum. */
 internal fun usedFractionOf(usedBytes: Long, freeBytes: Long): Float {

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsScreen.kt
@@ -21,9 +21,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.Logout
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -38,6 +41,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import pe.net.libre.mixtapehaven.data.download.VideoDownloadQuality
 import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.ui.components.BackTopBar
 import pe.net.libre.mixtapehaven.ui.components.SectionLabel
@@ -48,6 +52,7 @@ import pe.net.libre.mixtapehaven.ui.theme.Accent
 import pe.net.libre.mixtapehaven.ui.theme.AccentInk
 import pe.net.libre.mixtapehaven.ui.theme.Coral
 import pe.net.libre.mixtapehaven.ui.theme.Stroke
+import pe.net.libre.mixtapehaven.ui.theme.Surface
 import pe.net.libre.mixtapehaven.ui.theme.TextMuted
 import pe.net.libre.mixtapehaven.ui.theme.TextPrimary
 import pe.net.libre.mixtapehaven.ui.theme.TextSecondary
@@ -60,13 +65,32 @@ fun SettingsScreen(
     modifier: Modifier = Modifier,
 ) {
     val viewModel = appViewModel {
-        SettingsViewModel(it.sessionStore, it.downloadSettingsStore, it.downloadManager, it.diagnosticsLog)
+        SettingsViewModel(
+            it.sessionStore,
+            it.downloadSettingsStore,
+            it.downloadManager,
+            it.videoDownloadManager,
+            it.diagnosticsLog,
+        )
     }
     val automaticDownloads by viewModel.autoDownloadEnabled.collectAsState()
     val storageUsed by viewModel.storageUsedLabel.collectAsState()
+    val videoQuality by viewModel.videoQuality.collectAsState()
     val userName by viewModel.userName.collectAsState()
     val serverHost by viewModel.serverHost.collectAsState()
     var wifiOnly by remember { mutableStateOf(true) }
+    var showQualityPicker by remember { mutableStateOf(false) }
+
+    if (showQualityPicker) {
+        VideoQualityDialog(
+            selected = videoQuality,
+            onSelect = {
+                viewModel.setVideoQuality(it)
+                showQualityPicker = false
+            },
+            onDismiss = { showQualityPicker = false },
+        )
+    }
 
     val context = LocalContext.current
 
@@ -133,6 +157,12 @@ fun SettingsScreen(
                 )
                 HorizontalDivider(color = Stroke)
                 SettingLinkRow(title = "Audio quality", value = "Lossless", onClick = {})
+                HorizontalDivider(color = Stroke)
+                SettingLinkRow(
+                    title = "Video download quality",
+                    value = videoQuality.label,
+                    onClick = { showQualityPicker = true },
+                )
                 HorizontalDivider(color = Stroke)
                 SettingLinkRow(title = "Storage used", value = storageUsed, onClick = onOpenDownloads)
             }
@@ -202,6 +232,49 @@ private fun shareDiagnostics(context: Context, log: String) {
     } catch (_: ActivityNotFoundException) {
         Toast.makeText(context, "No app available to share diagnostics", Toast.LENGTH_SHORT).show()
     }
+}
+
+/** Picker for the transcode cap applied to video downloads (1080p / 720p / 480p). */
+@Composable
+private fun VideoQualityDialog(
+    selected: VideoDownloadQuality,
+    onSelect: (VideoDownloadQuality) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Surface,
+        title = { Text("Video download quality", style = MaterialTheme.typography.titleMedium, color = TextPrimary) },
+        text = {
+            Column {
+                VideoDownloadQuality.entries.forEach { quality ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelect(quality) }
+                            .padding(vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        RadioButton(
+                            selected = quality == selected,
+                            onClick = { onSelect(quality) },
+                            colors = RadioButtonDefaults.colors(selectedColor = Accent, unselectedColor = TextMuted),
+                        )
+                        Text(quality.label, style = MaterialTheme.typography.bodyMedium, color = TextPrimary)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Text(
+                "Done",
+                style = MaterialTheme.typography.titleMedium,
+                color = Accent,
+                modifier = Modifier.clickable(onClick = onDismiss).padding(8.dp),
+            )
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/settings/SettingsViewModel.kt
@@ -5,20 +5,24 @@ import androidx.lifecycle.viewModelScope
 import java.net.URI
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import pe.net.libre.mixtapehaven.data.diagnostics.DiagnosticsLog
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
 import pe.net.libre.mixtapehaven.data.download.DownloadSettingsStore
+import pe.net.libre.mixtapehaven.data.download.VideoDownloadManager
+import pe.net.libre.mixtapehaven.data.download.VideoDownloadQuality
 import pe.net.libre.mixtapehaven.data.download.formatBytes
 import pe.net.libre.mixtapehaven.data.session.SessionStore
 
-/** Backs the Settings screen: persists the auto-download toggle and surfaces real storage usage. */
+/** Backs the Settings screen: persists download preferences and surfaces real storage usage. */
 class SettingsViewModel(
     sessionStore: SessionStore,
     private val settingsStore: DownloadSettingsStore,
     downloadManager: DownloadManager,
+    videoDownloadManager: VideoDownloadManager,
     private val diagnostics: DiagnosticsLog,
 ) : ViewModel() {
 
@@ -37,12 +41,20 @@ class SettingsViewModel(
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), true)
 
     val storageUsedLabel: StateFlow<String> =
-        downloadManager.totalSizeBytes
-            .map { formatBytes(it) }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), formatBytes(0))
+        combine(downloadManager.totalSizeBytes, videoDownloadManager.totalSizeBytes) { audio, video ->
+            formatBytes(audio + video)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), formatBytes(0))
+
+    val videoQuality: StateFlow<VideoDownloadQuality> =
+        settingsStore.videoQuality
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), VideoDownloadQuality.DEFAULT)
 
     fun setAutoDownloadEnabled(enabled: Boolean) {
         viewModelScope.launch { settingsStore.setAutoDownloadEnabled(enabled) }
+    }
+
+    fun setVideoQuality(quality: VideoDownloadQuality) {
+        viewModelScope.launch { settingsStore.setVideoQuality(quality) }
     }
 
     /** A plain-text snapshot of the recent diagnostic events, for the Share diagnostics export. */

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailScreen.kt
@@ -1,5 +1,6 @@
 package pe.net.libre.mixtapehaven.ui.screens.video
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -31,10 +32,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
@@ -62,6 +65,14 @@ fun VideoDetailScreen(
     val viewModel = appViewModel { VideoDetailViewModel(it.repository, it.videoDownloadManager, itemId) }
     val state by viewModel.state.collectAsState()
     val downloadUi by viewModel.downloadUi.collectAsState()
+
+    // Downloads fail silently in the manager (logcat only); give the user the reason here.
+    val context = LocalContext.current
+    LaunchedEffect(viewModel) {
+        viewModel.downloadErrors.collect { message ->
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
+    }
 
     Column(
         modifier = modifier

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailScreen.kt
@@ -1,6 +1,7 @@
 package pe.net.libre.mixtapehaven.ui.screens.video
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -23,6 +24,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -42,6 +46,7 @@ import pe.net.libre.mixtapehaven.model.VideoKind
 import pe.net.libre.mixtapehaven.ui.components.Artwork
 import pe.net.libre.mixtapehaven.ui.theme.Accent
 import pe.net.libre.mixtapehaven.ui.theme.AccentInk
+import pe.net.libre.mixtapehaven.ui.theme.Stroke
 import pe.net.libre.mixtapehaven.ui.theme.Surface2
 import pe.net.libre.mixtapehaven.ui.theme.TextMuted
 import pe.net.libre.mixtapehaven.ui.theme.TextPrimary
@@ -54,8 +59,9 @@ fun VideoDetailScreen(
     onPlay: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val viewModel = appViewModel { VideoDetailViewModel(it.repository, itemId) }
+    val viewModel = appViewModel { VideoDetailViewModel(it.repository, it.videoDownloadManager, itemId) }
     val state by viewModel.state.collectAsState()
+    val downloadUi by viewModel.downloadUi.collectAsState()
 
     Column(
         modifier = modifier
@@ -70,8 +76,11 @@ fun VideoDetailScreen(
             item != null -> DetailBody(
                 item = item,
                 episodes = state.episodes,
+                downloadUi = downloadUi,
                 onPlay = { viewModel.playTarget()?.let { onPlay(it.id) } },
                 onPlayEpisode = { onPlay(it.id) },
+                onDownload = viewModel::download,
+                onRemoveDownload = viewModel::removeDownload,
             )
             state.loading -> Unit
             else -> Text(
@@ -118,31 +127,32 @@ private fun Backdrop(item: VideoItem?, onBack: () -> Unit) {
 private fun DetailBody(
     item: VideoItem,
     episodes: List<VideoItem>,
+    downloadUi: VideoDownloadUi,
     onPlay: () -> Unit,
     onPlayEpisode: (VideoItem) -> Unit,
+    onDownload: (VideoItem) -> Unit,
+    onRemoveDownload: (String) -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text(item.title, style = MaterialTheme.typography.displayMedium, color = TextPrimary)
-            val meta = listOfNotNull(
-                item.yearLabel.ifEmpty { null },
-                when (item.kind) {
-                    VideoKind.SERIES -> "Series"
-                    else -> item.runtimeLabel.ifEmpty { null }
-                },
-            ).joinToString(" · ")
-            if (meta.isNotEmpty()) {
-                Text(meta, style = MaterialTheme.typography.bodySmall, color = TextSecondary)
-            }
-        }
+        TitleBlock(item)
 
         PlayButton(
             label = if (item.kind != VideoKind.SERIES && item.resumePositionMs > 0) "Resume" else "Play",
             onClick = onPlay,
         )
+
+        // Series are downloaded per-episode via the row icons; movies/episodes get a single button.
+        if (item.kind != VideoKind.SERIES) {
+            DownloadButton(
+                item = item,
+                downloadUi = downloadUi,
+                onDownload = onDownload,
+                onRemoveDownload = onRemoveDownload,
+            )
+        }
 
         if (item.overview.isNotEmpty()) {
             Text(item.overview, style = MaterialTheme.typography.bodyMedium, color = TextSecondary)
@@ -152,10 +162,91 @@ private fun DetailBody(
             Text("Episodes", style = MaterialTheme.typography.titleMedium, color = TextPrimary)
             Column {
                 episodes.forEach { episode ->
-                    EpisodeRow(episode = episode, onClick = { onPlayEpisode(episode) })
+                    EpisodeRow(
+                        episode = episode,
+                        downloadUi = downloadUi,
+                        onClick = { onPlayEpisode(episode) },
+                        onDownload = onDownload,
+                        onRemoveDownload = onRemoveDownload,
+                    )
                 }
             }
         }
+    }
+}
+
+/** Display title with the "1931 · 1h 14m" (or "· Series") meta line under it. */
+@Composable
+private fun TitleBlock(item: VideoItem) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(item.title, style = MaterialTheme.typography.displayMedium, color = TextPrimary)
+        val meta = listOfNotNull(
+            item.yearLabel.ifEmpty { null },
+            when (item.kind) {
+                VideoKind.SERIES -> "Series"
+                else -> item.runtimeLabel.ifEmpty { null }
+            },
+        ).joinToString(" · ")
+        if (meta.isNotEmpty()) {
+            Text(meta, style = MaterialTheme.typography.bodySmall, color = TextSecondary)
+        }
+    }
+}
+
+/**
+ * Secondary full-width control cycling through the download lifecycle: Download -> transcoding
+ * progress (tap cancels) -> Downloaded (tap removes).
+ */
+@Composable
+private fun DownloadButton(
+    item: VideoItem,
+    downloadUi: VideoDownloadUi,
+    onDownload: (VideoItem) -> Unit,
+    onRemoveDownload: (String) -> Unit,
+) {
+    val inFlightLabel = downloadUi.inFlightLabels[item.id]
+    val downloaded = item.id in downloadUi.downloadedIds
+    val (label, onClick) = when {
+        downloaded -> "Downloaded · Remove" to { onRemoveDownload(item.id) }
+        inFlightLabel != null -> "Downloading · $inFlightLabel · Cancel" to { onRemoveDownload(item.id) }
+        else -> "Download" to { onDownload(item) }
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .border(1.dp, Stroke, RoundedCornerShape(14.dp))
+            .clickable(role = Role.Button, onClick = onClick)
+            .padding(vertical = 14.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        when {
+            downloaded -> Icon(
+                Icons.Outlined.Check,
+                contentDescription = null,
+                tint = Accent,
+                modifier = Modifier.size(20.dp),
+            )
+            inFlightLabel != null -> CircularProgressIndicator(
+                color = Accent,
+                trackColor = Surface2,
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(18.dp),
+            )
+            else -> Icon(
+                Icons.Outlined.ArrowDownward,
+                contentDescription = null,
+                tint = TextPrimary,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        Spacer(Modifier.width(8.dp))
+        Text(
+            label,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = TextPrimary,
+        )
     }
 }
 
@@ -213,9 +304,15 @@ private fun EpisodeThumb(episode: VideoItem) {
     }
 }
 
-/** One episode: 16:9 still, title, "S2 E4 · 42m" meta, with a resume progress bar when started. */
+/** One episode: 16:9 still, title, "S2 E4 · 42m" meta, download state control, and play affordance. */
 @Composable
-private fun EpisodeRow(episode: VideoItem, onClick: () -> Unit) {
+private fun EpisodeRow(
+    episode: VideoItem,
+    downloadUi: VideoDownloadUi,
+    onClick: () -> Unit,
+    onDownload: (VideoItem) -> Unit,
+    onRemoveDownload: (String) -> Unit,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -241,11 +338,54 @@ private fun EpisodeRow(episode: VideoItem, onClick: () -> Unit) {
                 Text(meta, style = MaterialTheme.typography.bodySmall, color = TextMuted)
             }
         }
+        EpisodeDownloadIcon(episode, downloadUi, onDownload, onRemoveDownload)
         Icon(
             Icons.Filled.PlayArrow,
             contentDescription = "Play episode",
             tint = TextSecondary,
             modifier = Modifier.size(22.dp),
         )
+    }
+}
+
+/** Download state for one episode: arrow (download), spinner (cancel), or check (remove). */
+@Composable
+private fun EpisodeDownloadIcon(
+    episode: VideoItem,
+    downloadUi: VideoDownloadUi,
+    onDownload: (VideoItem) -> Unit,
+    onRemoveDownload: (String) -> Unit,
+) {
+    val inFlight = episode.id in downloadUi.inFlightLabels
+    val downloaded = episode.id in downloadUi.downloadedIds
+    Box(
+        modifier = Modifier
+            .size(36.dp)
+            .clip(CircleShape)
+            .clickable(role = Role.Button) {
+                if (downloaded || inFlight) onRemoveDownload(episode.id) else onDownload(episode)
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        when {
+            downloaded -> Icon(
+                Icons.Outlined.Check,
+                contentDescription = "Remove download",
+                tint = Accent,
+                modifier = Modifier.size(20.dp),
+            )
+            inFlight -> CircularProgressIndicator(
+                color = Accent,
+                trackColor = Surface2,
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(18.dp),
+            )
+            else -> Icon(
+                Icons.Outlined.ArrowDownward,
+                contentDescription = "Download episode",
+                tint = TextMuted,
+                modifier = Modifier.size(20.dp),
+            )
+        }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailViewModel.kt
@@ -41,6 +41,9 @@ class VideoDetailViewModel(
     private val _state = MutableStateFlow(UiState())
     val state: StateFlow<UiState> = _state.asStateFlow()
 
+    /** One human-readable message per failed download; the screen toasts these. */
+    val downloadErrors = downloadManager.errors
+
     val downloadUi: StateFlow<VideoDownloadUi> =
         combine(downloadManager.downloads, downloadManager.progress) { rows, progress ->
             VideoDownloadUi(

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailViewModel.kt
@@ -3,16 +3,31 @@ package pe.net.libre.mixtapehaven.ui.screens.video
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.data.download.VideoDownloadManager
+import pe.net.libre.mixtapehaven.data.download.formatBytes
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
 import pe.net.libre.mixtapehaven.model.VideoItem
 import pe.net.libre.mixtapehaven.model.VideoKind
 
+/**
+ * Per-item download state shown on the detail screen: [downloadedIds] have a saved offline copy;
+ * [inFlightLabels] maps an actively downloading id to its progress label (e.g. "142 MB").
+ */
+data class VideoDownloadUi(
+    val downloadedIds: Set<String> = emptySet(),
+    val inFlightLabels: Map<String, String> = emptyMap(),
+)
+
 class VideoDetailViewModel(
     private val repository: JellyfinRepository,
+    private val downloadManager: VideoDownloadManager,
     private val itemId: String,
 ) : ViewModel() {
 
@@ -25,6 +40,14 @@ class VideoDetailViewModel(
 
     private val _state = MutableStateFlow(UiState())
     val state: StateFlow<UiState> = _state.asStateFlow()
+
+    val downloadUi: StateFlow<VideoDownloadUi> =
+        combine(downloadManager.downloads, downloadManager.progress) { rows, progress ->
+            VideoDownloadUi(
+                downloadedIds = rows.filter { it.complete }.map { it.id }.toSet(),
+                inFlightLabels = progress.mapValues { (_, p) -> formatBytes(p.bytes) },
+            )
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), VideoDownloadUi())
 
     init {
         load()
@@ -50,6 +73,17 @@ class VideoDetailViewModel(
 
     /** See [selectPlayTarget]. Null while loading or on error. */
     fun playTarget(): VideoItem? = selectPlayTarget(_state.value.item, _state.value.episodes)
+
+    fun download(item: VideoItem) = downloadManager.download(item)
+
+    /** Cancels an in-flight download or deletes the saved copy of [id]. */
+    fun removeDownload(id: String) {
+        viewModelScope.launch { downloadManager.remove(id) }
+    }
+
+    private companion object {
+        const val STOP_TIMEOUT_MS = 5_000L
+    }
 }
 
 /**

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/download/DownloadedVideoMappingTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/download/DownloadedVideoMappingTest.kt
@@ -1,0 +1,41 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import pe.net.libre.mixtapehaven.model.VideoKind
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadedVideoMappingTest {
+
+    private fun row(kind: String) = DownloadedVideo(
+        id = "abc",
+        title = "Dracula",
+        kind = kind,
+        seriesName = null,
+        seasonEpisodeLabel = null,
+        runtimeLabel = "1h 14m",
+        posterUrl = null,
+        artColorArgb = 0xFF6C8A7A.toInt(),
+        qualityLabel = "720p",
+        filePath = "/data/x.mp4",
+        sizeBytes = 1_000,
+        complete = true,
+    )
+
+    @Test
+    fun `round-trips the persisted kind back into the domain model`() {
+        assertEquals(VideoKind.EPISODE, row("EPISODE").toVideoItem().kind)
+        assertEquals(VideoKind.MOVIE, row("MOVIE").toVideoItem().kind)
+    }
+
+    @Test
+    fun `an unknown persisted kind degrades to movie instead of crashing`() {
+        assertEquals(VideoKind.MOVIE, row("HOLOGRAM").toVideoItem().kind)
+    }
+
+    @Test
+    fun `maps display fields through unchanged`() {
+        val item = row("MOVIE").toVideoItem()
+        assertEquals("Dracula", item.title)
+        assertEquals("1h 14m", item.runtimeLabel)
+    }
+}

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadQualityTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/download/VideoDownloadQualityTest.kt
@@ -1,0 +1,23 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VideoDownloadQualityTest {
+
+    @Test
+    fun `fromName resolves a persisted quality by enum name`() {
+        assertEquals(VideoDownloadQuality.SD_480, VideoDownloadQuality.fromName("SD_480"))
+        assertEquals(VideoDownloadQuality.HD_1080, VideoDownloadQuality.fromName("HD_1080"))
+    }
+
+    @Test
+    fun `fromName falls back to the default for unknown values`() {
+        assertEquals(VideoDownloadQuality.DEFAULT, VideoDownloadQuality.fromName("4K"))
+    }
+
+    @Test
+    fun `fromName falls back to the default when nothing was persisted`() {
+        assertEquals(VideoDownloadQuality.DEFAULT, VideoDownloadQuality.fromName(null))
+    }
+}


### PR DESCRIPTION
## Summary

Movies and episodes can now be saved for offline playback. Downloads are **user-triggered** (no auto-download for video, unlike audio) and fetched as h264/aac **MPEG-TS transcodes** capped at the quality chosen in Settings (1080p / 720p / 480p, default 720p), so a phone-sized copy is stored instead of the original file.

- **Video Detail**: a Download button for movies/episodes and per-episode download icons for series, cycling Download → Downloading (streamed-bytes label, tap to cancel) → Downloaded (tap to remove).
- **Offline playback for free**: `AppContainer.videoSourceResolver` (the seam from step 1, #148) serves the saved local file as the only candidate when one exists, else falls back to the remote direct-play/HLS candidates. Zero player changes.
- **Downloads screen**: new "Movies & shows" section (poster, series/quality/size meta, per-item cancel/delete, tap-to-play), two-segment storage bar (music + video), and Remove all now clears both libraries.
- **Data layer**: `DownloadedVideo` entity + DAO, DB v1→v2 **additive migration** (existing audio downloads survive), `VideoDownloadManager` mirroring the audio manager (partial-file cleanup, 500 MB free-space guard, in-flight rows).

## Bugs caught by on-device verification (fixed in the second commit)

1. **Progressive mp4 transcodes are unplayable once saved**: ffmpeg cannot backpatch the `mdat` size over a non-seekable HTTP response, so the `moov` index at the tail is unreachable and ExoPlayer rejects the file as malformed. Switched the download container to MPEG-TS, which needs no finalization.
2. **Downloads died on screen-off**: Android freezes the cached process (`SocketException: Software caused connection abort`). A minimal dataSync foreground service is now held while downloads are active.
3. **Downloaded videos were unreachable offline** (Home rail and Detail are server-backed): Downloads-screen video rows are now tappable to play.

## Verification (Pixel 8, own server)

- Set quality to 480p via the new Settings dialog; verified persistence.
- Downloaded Before Sunset (1h 20m → 1.0 GB TS) **with the screen off the entire ~4 min** — dataSync FGS confirmed via `dumpsys activity services` (`isForeground=true`).
- Airplane mode → Downloads → tap row → movie plays from the local file (screenshot + fresh `event:started` in `dumpsys audio`).
- Cancel/remove paths exercised (removed the earlier broken mp4 via the Downloaded · Remove button; partial cleanup confirmed on abort).
- `test`, `detekt`, `lintDebug` all green; DB migration verified against a live v1 install.

## Deferred to step 3

- Offline Home view for downloaded movies (rail backed by the local library; offline taps route straight to the player).
- `tvShowsApi.getNextUp` for series resume; header-based stream auth instead of `?ApiKey=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)