### PR TITLE
feat: continue watching, next episode, and offline resume (video step 3)

### DIFF
--- a/app/schemas/pe.net.libre.mixtapehaven.data.download.DownloadDatabase/3.json
+++ b/app/schemas/pe.net.libre.mixtapehaven.data.download.DownloadDatabase/3.json
@@ -1,0 +1,233 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "1128b1976054751408185f9838d4c059",
+    "entities": [
+      {
+        "tableName": "downloaded_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `durationLabel` TEXT NOT NULL, `imageUrl` TEXT, `artColorArgb` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `complete` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationLabel",
+            "columnName": "durationLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artColorArgb",
+            "columnName": "artColorArgb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "complete",
+            "columnName": "complete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "downloaded_videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `kind` TEXT NOT NULL, `seriesName` TEXT, `seasonEpisodeLabel` TEXT, `runtimeLabel` TEXT NOT NULL, `posterUrl` TEXT, `artColorArgb` INTEGER NOT NULL, `qualityLabel` TEXT NOT NULL, `filePath` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `complete` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonEpisodeLabel",
+            "columnName": "seasonEpisodeLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "runtimeLabel",
+            "columnName": "runtimeLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artColorArgb",
+            "columnName": "artColorArgb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "qualityLabel",
+            "columnName": "qualityLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "complete",
+            "columnName": "complete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "video_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `runtimeMs` INTEGER NOT NULL, `updatedAtMs` INTEGER NOT NULL, `title` TEXT NOT NULL, `kind` TEXT NOT NULL, `seriesName` TEXT, `seasonEpisodeLabel` TEXT, `posterUrl` TEXT, `backdropUrl` TEXT, `artColorArgb` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeMs",
+            "columnName": "runtimeMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtMs",
+            "columnName": "updatedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonEpisodeLabel",
+            "columnName": "seasonEpisodeLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropUrl",
+            "columnName": "backdropUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artColorArgb",
+            "columnName": "artColorArgb",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1128b1976054751408185f9838d4c059')"
+    ]
+  }
+}

--- a/app/schemas/pe.net.libre.mixtapehaven.data.download.DownloadDatabase/3.json
+++ b/app/schemas/pe.net.libre.mixtapehaven.data.download.DownloadDatabase/3.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 3,
-    "identityHash": "1128b1976054751408185f9838d4c059",
+    "identityHash": "5ce1504a2a327468d41e4df286626603",
     "entities": [
       {
         "tableName": "downloaded_tracks",
@@ -152,7 +152,7 @@
       },
       {
         "tableName": "video_progress",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `runtimeMs` INTEGER NOT NULL, `updatedAtMs` INTEGER NOT NULL, `title` TEXT NOT NULL, `kind` TEXT NOT NULL, `seriesName` TEXT, `seasonEpisodeLabel` TEXT, `posterUrl` TEXT, `backdropUrl` TEXT, `artColorArgb` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `runtimeMs` INTEGER NOT NULL, `updatedAtMs` INTEGER NOT NULL, `title` TEXT NOT NULL, `kind` TEXT NOT NULL, `seriesName` TEXT, `seriesId` TEXT, `seasonEpisodeLabel` TEXT, `posterUrl` TEXT, `backdropUrl` TEXT, `artColorArgb` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -196,6 +196,11 @@
             "affinity": "TEXT"
           },
           {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT"
+          },
+          {
             "fieldPath": "seasonEpisodeLabel",
             "columnName": "seasonEpisodeLabel",
             "affinity": "TEXT"
@@ -227,7 +232,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1128b1976054751408185f9838d4c059')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5ce1504a2a327468d41e4df286626603')"
     ]
   }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDatabase.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDatabase.kt
@@ -43,8 +43,8 @@ abstract class DownloadDatabase : RoomDatabase() {
                     "CREATE TABLE IF NOT EXISTS `video_progress` (" +
                         "`id` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `runtimeMs` INTEGER NOT NULL, " +
                         "`updatedAtMs` INTEGER NOT NULL, `title` TEXT NOT NULL, `kind` TEXT NOT NULL, " +
-                        "`seriesName` TEXT, `seasonEpisodeLabel` TEXT, `posterUrl` TEXT, `backdropUrl` TEXT, " +
-                        "`artColorArgb` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+                        "`seriesName` TEXT, `seriesId` TEXT, `seasonEpisodeLabel` TEXT, `posterUrl` TEXT, " +
+                        "`backdropUrl` TEXT, `artColorArgb` INTEGER NOT NULL, PRIMARY KEY(`id`))",
                 )
             }
         }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDatabase.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/DownloadDatabase.kt
@@ -8,12 +8,18 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 /** Room database holding the offline download library (audio tracks and videos). */
-@Database(entities = [DownloadedTrack::class, DownloadedVideo::class], version = 2, exportSchema = true)
+@Database(
+    entities = [DownloadedTrack::class, DownloadedVideo::class, VideoProgress::class],
+    version = 3,
+    exportSchema = true,
+)
 abstract class DownloadDatabase : RoomDatabase() {
 
     abstract fun downloadDao(): DownloadDao
 
     abstract fun videoDownloadDao(): VideoDownloadDao
+
+    abstract fun videoProgressDao(): VideoProgressDao
 
     companion object {
         /** v1 -> v2: adds the video download table. Additive so existing audio downloads survive. */
@@ -30,12 +36,25 @@ abstract class DownloadDatabase : RoomDatabase() {
             }
         }
 
+        /** v2 -> v3: adds the local watch-position table backing offline resume and Continue watching. */
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `video_progress` (" +
+                        "`id` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `runtimeMs` INTEGER NOT NULL, " +
+                        "`updatedAtMs` INTEGER NOT NULL, `title` TEXT NOT NULL, `kind` TEXT NOT NULL, " +
+                        "`seriesName` TEXT, `seasonEpisodeLabel` TEXT, `posterUrl` TEXT, `backdropUrl` TEXT, " +
+                        "`artColorArgb` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+                )
+            }
+        }
+
         /** Build the app's download database in the default location. */
         fun build(context: Context): DownloadDatabase =
             Room.databaseBuilder(
                 context.applicationContext,
                 DownloadDatabase::class.java,
                 "downloads.db",
-            ).addMigrations(MIGRATION_1_2).build()
+            ).addMigrations(MIGRATION_1_2, MIGRATION_2_3).build()
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoProgress.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoProgress.kt
@@ -31,6 +31,8 @@ data class VideoProgress(
     val title: String,
     val kind: String,
     val seriesName: String?,
+    /** Kept so an episode resumed from this row can still resolve its series for autoplay. */
+    val seriesId: String?,
     val seasonEpisodeLabel: String?,
     val posterUrl: String?,
     val backdropUrl: String?,
@@ -49,6 +51,7 @@ internal fun VideoProgress.toVideoItem(): VideoItem = VideoItem(
     resumePositionMs = positionMs,
     lastPlayedAtMs = updatedAtMs,
     seriesName = seriesName,
+    seriesId = seriesId,
     seasonEpisodeLabel = seasonEpisodeLabel,
 )
 
@@ -61,6 +64,7 @@ internal fun VideoItem.toProgress(positionMs: Long, runtimeMs: Long, nowMs: Long
     title = title,
     kind = kind.name,
     seriesName = seriesName,
+    seriesId = seriesId,
     seasonEpisodeLabel = seasonEpisodeLabel,
     posterUrl = posterUrl,
     backdropUrl = backdropUrl,
@@ -74,6 +78,14 @@ interface VideoProgressDao {
     /** In-progress titles, most recently watched first, for the Continue watching rail. */
     @Query("SELECT * FROM video_progress WHERE positionMs > 0 ORDER BY updatedAtMs DESC LIMIT :limit")
     fun observeContinueWatching(limit: Int): Flow<List<VideoProgress>>
+
+    /**
+     * Ids of titles finished locally. These are kept as position-0 tombstones rather than deleted:
+     * the server's Continue Watching snapshot still lists them until it is refetched, and without a
+     * local record to veto it the just-finished title would reappear in the rail.
+     */
+    @Query("SELECT id FROM video_progress WHERE positionMs <= 0")
+    fun observeFinishedIds(): Flow<List<String>>
 
     @Query("SELECT * FROM video_progress WHERE id = :id")
     suspend fun findById(id: String): VideoProgress?

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoProgress.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/download/VideoProgress.kt
@@ -1,0 +1,89 @@
+package pe.net.libre.mixtapehaven.data.download
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
+
+/**
+ * A locally recorded watch position for one movie or episode.
+ *
+ * The server owns the canonical resume point, but it is unreachable offline — and a downloaded
+ * title is exactly the one you watch offline. Every position update is therefore written here too,
+ * stamped with [updatedAtMs], and the fresher of the two wins on resume (see
+ * [pe.net.libre.mixtapehaven.data.playback.resolveResumePosition]).
+ *
+ * The display fields are denormalised so the Continue watching rail can render with no network at
+ * all; they are refreshed on every write from whatever the player already knows about the item.
+ */
+@Entity(tableName = "video_progress")
+data class VideoProgress(
+    @PrimaryKey val id: String,
+    val positionMs: Long,
+    val runtimeMs: Long,
+    val updatedAtMs: Long,
+    val title: String,
+    val kind: String,
+    val seriesName: String?,
+    val seasonEpisodeLabel: String?,
+    val posterUrl: String?,
+    val backdropUrl: String?,
+    val artColorArgb: Int,
+)
+
+/** Map a local progress row back to a UI [VideoItem]. */
+internal fun VideoProgress.toVideoItem(): VideoItem = VideoItem(
+    id = id,
+    title = title,
+    kind = VideoKind.entries.firstOrNull { it.name == kind } ?: VideoKind.MOVIE,
+    posterUrl = posterUrl,
+    backdropUrl = backdropUrl,
+    artColor = Color(artColorArgb),
+    runtimeMs = runtimeMs,
+    resumePositionMs = positionMs,
+    lastPlayedAtMs = updatedAtMs,
+    seriesName = seriesName,
+    seasonEpisodeLabel = seasonEpisodeLabel,
+)
+
+/** Build a progress row for [item] at [positionMs], stamped [nowMs]. */
+internal fun VideoItem.toProgress(positionMs: Long, runtimeMs: Long, nowMs: Long) = VideoProgress(
+    id = id,
+    positionMs = positionMs,
+    runtimeMs = if (runtimeMs > 0L) runtimeMs else this.runtimeMs,
+    updatedAtMs = nowMs,
+    title = title,
+    kind = kind.name,
+    seriesName = seriesName,
+    seasonEpisodeLabel = seasonEpisodeLabel,
+    posterUrl = posterUrl,
+    backdropUrl = backdropUrl,
+    artColorArgb = artColor.toArgb(),
+)
+
+/** Room access to locally recorded video watch positions. */
+@Dao
+interface VideoProgressDao {
+
+    /** In-progress titles, most recently watched first, for the Continue watching rail. */
+    @Query("SELECT * FROM video_progress WHERE positionMs > 0 ORDER BY updatedAtMs DESC LIMIT :limit")
+    fun observeContinueWatching(limit: Int): Flow<List<VideoProgress>>
+
+    @Query("SELECT * FROM video_progress WHERE id = :id")
+    suspend fun findById(id: String): VideoProgress?
+
+    @Upsert
+    suspend fun upsert(progress: VideoProgress)
+
+    @Query("DELETE FROM video_progress WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    @Query("DELETE FROM video_progress")
+    suspend fun clear()
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
@@ -8,6 +8,7 @@ import org.jellyfin.sdk.api.client.extensions.audioApi
 import org.jellyfin.sdk.api.client.extensions.authenticateUserByName
 import org.jellyfin.sdk.api.client.extensions.dynamicHlsApi
 import org.jellyfin.sdk.api.client.extensions.itemsApi
+import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
 import org.jellyfin.sdk.api.client.extensions.playStateApi
 import org.jellyfin.sdk.api.client.extensions.tvShowsApi
 import org.jellyfin.sdk.api.client.extensions.userApi
@@ -15,11 +16,16 @@ import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.EncodingContext
+import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
+import org.jellyfin.sdk.model.api.MediaType
 import org.jellyfin.sdk.model.api.PlayMethod
+import org.jellyfin.sdk.model.api.PlaybackInfoDto
 import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.api.request.GetItemsRequest
+import org.jellyfin.sdk.model.api.request.GetNextUpRequest
+import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest
 import pe.net.libre.mixtapehaven.data.session.Session
 import pe.net.libre.mixtapehaven.data.session.SessionStore
 import pe.net.libre.mixtapehaven.model.Album
@@ -29,6 +35,12 @@ import java.util.UUID
 
 /** Lifecycle moment of video playback reported to the server via [JellyfinRepository.reportVideoPlayback]. */
 enum class VideoPlaybackEvent { STARTED, PROGRESS, STOPPED }
+
+/**
+ * Image types requested for Continue watching / Next Up rows. BACKDROP and THUMB are the wide art
+ * the 16:9 still wants; PRIMARY is the fallback (and is itself a 16:9 still for episodes).
+ */
+private val CONTINUE_IMAGE_TYPES = listOf(ImageType.BACKDROP, ImageType.THUMB, ImageType.PRIMARY)
 
 /** Wraps the Jellyfin Kotlin SDK: authentication, library browsing, search, and stream/image URLs. */
 class JellyfinRepository(
@@ -186,11 +198,34 @@ class JellyfinRepository(
     }
 
     /**
+     * The id of the media source the server picked for [itemId], via a PlaybackInfo negotiation.
+     *
+     * Transcode URLs need a real MediaSource id. For a plain single-file library item that happens
+     * to equal the item id unhyphenated, but multi-version items (a 4K and a 1080p cut) and
+     * .strm-backed ones have their own ids, and guessing sends the server the wrong source. Falls
+     * back to the guess when the call fails, so a negotiation error degrades to the old behaviour
+     * rather than blocking playback.
+     */
+    suspend fun mediaSourceId(itemId: String): String {
+        val fallback = itemId.replace("-", "")
+        val client = api
+        val id = runCatching { UUID.fromString(itemId) }.getOrNull()
+        if (client == null || id == null) return fallback
+        return runCatching {
+            val info by client.mediaInfoApi.getPostedPlaybackInfo(
+                itemId = id,
+                data = PlaybackInfoDto(userId = userId, enableDirectPlay = true, enableTranscoding = true),
+            )
+            info.mediaSources.firstOrNull()?.id
+        }.getOrNull() ?: fallback
+    }
+
+    /**
      * Ordered stream URL candidates for [itemId]: direct play of the original file first, then an
      * HLS transcode pinned to h264/aac for anything the device cannot play natively. The player
      * tries them in order and falls through on error.
      */
-    fun videoStreamCandidates(itemId: String): List<String> {
+    suspend fun videoStreamCandidates(itemId: String): List<String> {
         val client = api
         val id = runCatching { UUID.fromString(itemId) }.getOrNull()
         if (client == null || id == null) return emptyList()
@@ -200,13 +235,55 @@ class JellyfinRepository(
         val hls = client.dynamicHlsApi
             .getMasterHlsVideoPlaylistUrl(
                 itemId = id,
-                // Known limitation: assumes the default single media source (see videoDownloadUrl).
-                mediaSourceId = itemId.replace("-", ""),
+                mediaSourceId = mediaSourceId(itemId),
                 videoCodec = "h264",
                 audioCodec = "aac",
             )
             .withApiKey(client)
         return listOf(direct, hls)
+    }
+
+    /**
+     * The next episode to watch in [seriesId] per the server's Next Up logic, or null when the
+     * series is finished or unwatched. Unlike scanning episodes for a resume position this is
+     * correct after an episode is watched to completion (Jellyfin zeroes its position, so a local
+     * scan would send the user back to the episode they just finished).
+     */
+    suspend fun nextUpEpisode(seriesId: String): VideoItem? {
+        val client = requireApi()
+        val id = runCatching { UUID.fromString(seriesId) }.getOrNull() ?: return null
+        val result by client.tvShowsApi.getNextUp(
+            GetNextUpRequest(
+                userId = userId,
+                seriesId = id,
+                fields = listOf(ItemFields.OVERVIEW),
+                limit = 1,
+                // Include the partially-watched episode itself, not just the one after it.
+                enableResumable = true,
+                enableImages = true,
+                enableImageTypes = CONTINUE_IMAGE_TYPES,
+            ),
+        )
+        return result.items.orEmpty().firstOrNull()?.toVideoItem(client)
+    }
+
+    /** The server's Continue Watching list: partially-watched movies and episodes, most recent first. */
+    suspend fun continueWatching(limit: Int = 12): List<VideoItem> {
+        val client = requireApi()
+        val result by client.itemsApi.getResumeItems(
+            GetResumeItemsRequest(
+                userId = userId,
+                limit = limit,
+                mediaTypes = listOf(MediaType.VIDEO),
+                includeItemTypes = listOf(BaseItemKind.MOVIE, BaseItemKind.EPISODE),
+                fields = listOf(ItemFields.OVERVIEW),
+                // Resume items come back without image tags unless asked for, which would leave
+                // every Continue watching still on its flat colour fallback.
+                enableImages = true,
+                enableImageTypes = CONTINUE_IMAGE_TYPES,
+            ),
+        )
+        return result.items.orEmpty().map { it.toVideoItem(client) }
     }
 
     /**
@@ -257,7 +334,7 @@ class JellyfinRepository(
      * never backpatch the mdat size, so the moov index at the tail is unreachable and ExoPlayer
      * rejects the saved file as malformed. TS needs no finalization and stays seekable.
      */
-    fun videoDownloadUrl(itemId: String, maxHeight: Int, videoBitRate: Int, audioBitRate: Int): String? {
+    suspend fun videoDownloadUrl(itemId: String, maxHeight: Int, videoBitRate: Int, audioBitRate: Int): String? {
         val client = api
         val id = runCatching { UUID.fromString(itemId) }.getOrNull()
         if (client == null || id == null) return null
@@ -266,11 +343,7 @@ class JellyfinRepository(
                 itemId = id,
                 container = "ts",
                 static = false,
-                // Known limitation: the default source id is the item id unhyphenated, which holds
-                // for plain single-file library items but not for multi-version or .strm-backed
-                // ones. The robust path is mediaInfoApi.getPostedPlaybackInfo and using
-                // mediaSources.first().id, as full clients do.
-                mediaSourceId = itemId.replace("-", ""),
+                mediaSourceId = mediaSourceId(itemId),
                 videoCodec = "h264",
                 audioCodec = "aac",
                 maxHeight = maxHeight,

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinRepository.kt
@@ -185,7 +185,13 @@ class JellyfinRepository(
         return item.toVideoItem(client)
     }
 
-    /** All episodes of [seriesId] in season/episode order, with overviews and resume positions. */
+    /**
+     * All episodes of [seriesId] in season/episode order, with overviews and resume positions.
+     *
+     * The sort is applied here rather than trusting the endpoint's default: autoplay picks the
+     * next episode positionally, so the ordering is load-bearing and should not be an implicit
+     * assumption about server behaviour.
+     */
     suspend fun seriesEpisodes(seriesId: String): List<VideoItem> {
         val client = requireApi()
         val id = runCatching { UUID.fromString(seriesId) }.getOrNull() ?: return emptyList()
@@ -194,17 +200,24 @@ class JellyfinRepository(
             userId = userId,
             fields = listOf(ItemFields.OVERVIEW),
         )
-        return result.items.orEmpty().map { it.toVideoItem(client) }
+        return result.items.orEmpty()
+            .map { it.toVideoItem(client) to it }
+            .sortedWith(compareBy({ it.second.parentIndexNumber ?: 0 }, { it.second.indexNumber ?: 0 }))
+            .map { it.first }
     }
 
     /**
      * The id of the media source the server picked for [itemId], via a PlaybackInfo negotiation.
      *
      * Transcode URLs need a real MediaSource id. For a plain single-file library item that happens
-     * to equal the item id unhyphenated, but multi-version items (a 4K and a 1080p cut) and
-     * .strm-backed ones have their own ids, and guessing sends the server the wrong source. Falls
-     * back to the guess when the call fails, so a negotiation error degrades to the old behaviour
-     * rather than blocking playback.
+     * to equal the item id unhyphenated, but .strm-backed items have their own, and guessing sends
+     * the server a source it does not know. Falls back to the guess when the call fails, so a
+     * negotiation error degrades to the old behaviour rather than blocking playback.
+     *
+     * Takes the first source the server lists, which is *not* a considered choice between the
+     * versions of a multi-version item (a 4K and a 1080p cut) — picking by requested quality would
+     * mean matching against each source's streams. Note also that this is an extra POST on the
+     * playback critical path, and that it opens a server-side play session.
      */
     suspend fun mediaSourceId(itemId: String): String {
         val fallback = itemId.replace("-", "")

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinVideoMapping.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinVideoMapping.kt
@@ -8,6 +8,8 @@ import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ImageType
 import pe.net.libre.mixtapehaven.model.VideoItem
 import pe.net.libre.mixtapehaven.model.VideoKind
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 /** Mapping from Jellyfin DTOs to the video domain model, kept out of [JellyfinRepository] for size. */
 
@@ -40,7 +42,9 @@ internal fun BaseItemDto.toVideoItem(client: ApiClient): VideoItem {
         artColor = videoColorFor(id.toString()),
         runtimeMs = runtimeMs,
         resumePositionMs = (userData?.playbackPositionTicks ?: 0L) / TICKS_PER_MS,
+        lastPlayedAtMs = userData?.lastPlayedDate?.toEpochMilliUtc() ?: 0L,
         seriesName = seriesName,
+        seriesId = seriesId?.toString(),
         seasonEpisodeLabel = if (type == BaseItemKind.EPISODE && parentIndexNumber != null && indexNumber != null) {
             "S$parentIndexNumber E$indexNumber"
         } else {
@@ -56,12 +60,18 @@ private fun BaseItemDto.videoPrimaryImageUrl(client: ApiClient): String? {
         .withApiKey(client)
 }
 
+/** Wide art for 16:9 surfaces: a real backdrop when present, else the THUMB some libraries use. */
 private fun BaseItemDto.backdropImageUrl(client: ApiClient): String? {
-    val tag = backdropImageTags?.firstOrNull() ?: return null
+    val backdrop = backdropImageTags?.firstOrNull()?.let { ImageType.BACKDROP to it }
+    val thumb = imageTags?.get(ImageType.THUMB)?.let { ImageType.THUMB to it }
+    val (type, tag) = backdrop ?: thumb ?: return null
     return client.imageApi
-        .getItemImageUrl(id, ImageType.BACKDROP, tag = tag, maxWidth = BACKDROP_MAX_WIDTH)
+        .getItemImageUrl(id, type, tag = tag, maxWidth = BACKDROP_MAX_WIDTH)
         .withApiKey(client)
 }
+
+/** Jellyfin serialises timestamps as zoneless UTC, so they are read back against [ZoneOffset.UTC]. */
+private fun LocalDateTime.toEpochMilliUtc(): Long = toInstant(ZoneOffset.UTC).toEpochMilli()
 
 internal fun formatRuntime(runtimeMs: Long): String {
     if (runtimeMs <= 0) return ""
@@ -69,6 +79,19 @@ internal fun formatRuntime(runtimeMs: Long): String {
     val hours = totalMinutes / 60
     val minutes = totalMinutes % 60
     return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+}
+
+/**
+ * Remaining watch time for the Continue watching card ("23 min left", "1h 12m left"). Empty when
+ * the runtime is unknown or the item is effectively finished, so the caller can drop the segment.
+ */
+internal fun formatTimeLeft(runtimeMs: Long, positionMs: Long): String {
+    val remainingMs = runtimeMs - positionMs
+    if (runtimeMs <= 0L || remainingMs < 60_000) return ""
+    val totalMinutes = remainingMs / 60_000
+    val hours = totalMinutes / 60
+    val minutes = totalMinutes % 60
+    return if (hours > 0) "${hours}h ${minutes}m left" else "$totalMinutes min left"
 }
 
 private val VIDEO_PALETTE = listOf(

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinVideoMapping.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinVideoMapping.kt
@@ -86,8 +86,9 @@ internal fun formatRuntime(runtimeMs: Long): String {
  * the runtime is unknown or the item is effectively finished, so the caller can drop the segment.
  */
 internal fun formatTimeLeft(runtimeMs: Long, positionMs: Long): String {
-    val remainingMs = runtimeMs - positionMs
-    if (runtimeMs <= 0L || remainingMs < 60_000) return ""
+    // An unknown runtime yields no remaining time at all, rather than a bogus countdown from 0.
+    val remainingMs = if (runtimeMs <= 0L) 0L else runtimeMs - positionMs
+    if (remainingMs < 60_000) return ""
     val totalMinutes = remainingMs / 60_000
     val hours = totalMinutes / 60
     val minutes = totalMinutes % 60

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/VideoProgressStore.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/VideoProgressStore.kt
@@ -2,6 +2,7 @@ package pe.net.libre.mixtapehaven.data.playback
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import pe.net.libre.mixtapehaven.data.download.VideoDownloadDao
 import pe.net.libre.mixtapehaven.data.download.VideoProgress
 import pe.net.libre.mixtapehaven.data.download.VideoProgressDao
 import pe.net.libre.mixtapehaven.data.download.toProgress
@@ -21,21 +22,34 @@ import pe.net.libre.mixtapehaven.model.VideoItem
 class VideoProgressStore(
     private val repository: JellyfinRepository,
     private val dao: VideoProgressDao,
+    private val downloadDao: VideoDownloadDao,
     private val now: () -> Long = System::currentTimeMillis,
 ) {
     /** Locally known in-progress titles, most recent first — the offline Continue watching source. */
     fun observeLocal(limit: Int = CONTINUE_LIMIT): Flow<List<VideoItem>> =
         dao.observeContinueWatching(limit).map { rows -> rows.map { it.toVideoItem() } }
 
+    /** Ids finished locally, which must be suppressed from a staler server Continue Watching list. */
+    fun observeFinishedIds(): Flow<Set<String>> = dao.observeFinishedIds().map { it.toSet() }
+
     /**
-     * The item to play for [itemId] and the position to start it at, merging the server's copy
-     * (authoritative metadata, may be unreachable) with the local row (always available).
+     * The item to play for [itemId] and the position to start it at.
+     *
+     * Three sources in descending authority: the server (best metadata, unreachable offline), the
+     * local progress row (present once the title has been played), and finally the download row.
+     * That last fallback is what lets a downloaded-but-never-played title start offline — without
+     * it the one case the offline feature exists for would fail to resolve an item at all.
      */
     suspend fun resolvePlayback(itemId: String): ResolvedPlayback {
         val local = dao.findById(itemId)
         val remote = runCatching { repository.videoItem(itemId) }.getOrNull()
+        val downloaded = if (remote == null && local == null) {
+            runCatching { downloadDao.findById(itemId) }.getOrNull()?.takeIf { it.complete }?.toVideoItem()
+        } else {
+            null
+        }
         return ResolvedPlayback(
-            item = remote ?: local?.toVideoItem(),
+            item = remote ?: local?.toVideoItem() ?: downloaded,
             positionMs = resolveResumePosition(local, remote),
         )
     }
@@ -54,18 +68,18 @@ class VideoProgressStore(
         paused: Boolean = false,
         transcoding: Boolean = false,
     ) {
-        if (isFinished(positionMs, runtimeMs)) {
-            // Finished: drop it from Continue watching instead of stranding it at 99%.
-            dao.deleteById(item.id)
-        } else {
-            dao.upsert(item.toProgress(positionMs, runtimeMs, now()))
-        }
+        // A finished title is stored at position 0 rather than deleted, so it both leaves the rail
+        // and leaves behind a tombstone that outvotes the server's staler "still in progress" copy.
+        val storedPosition = if (isFinished(positionMs, runtimeMs)) 0L else positionMs
+        dao.upsert(item.toProgress(storedPosition, runtimeMs, now()))
         repository.reportVideoPlayback(item.id, positionMs, event, paused = paused, transcoding = transcoding)
     }
 
-    /** Forget the local position for [itemId] (e.g. when its download is deleted). */
-    suspend fun clear(itemId: String) = dao.deleteById(itemId)
-
+    /**
+     * Forget every local watch position. Called on sign-out — positions are per-user, and deleting
+     * a *download* deliberately does not come here: the title stays in the library and the server
+     * still holds its resume point.
+     */
     suspend fun clearAll() = dao.clear()
 
     private companion object {

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/VideoProgressStore.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/VideoProgressStore.kt
@@ -1,0 +1,102 @@
+package pe.net.libre.mixtapehaven.data.playback
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import pe.net.libre.mixtapehaven.data.download.VideoProgress
+import pe.net.libre.mixtapehaven.data.download.VideoProgressDao
+import pe.net.libre.mixtapehaven.data.download.toProgress
+import pe.net.libre.mixtapehaven.data.download.toVideoItem
+import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
+import pe.net.libre.mixtapehaven.data.jellyfin.VideoPlaybackEvent
+import pe.net.libre.mixtapehaven.model.VideoItem
+
+/**
+ * Watch positions for video, mirrored locally so they survive with no server.
+ *
+ * Jellyfin owns the canonical resume point, but a downloaded title is precisely the one played
+ * offline: reporting would silently no-op and the next launch would restart from zero. Every
+ * position therefore lands in the local table as well, and [resolveResumePosition] arbitrates by
+ * recency when the two disagree.
+ */
+class VideoProgressStore(
+    private val repository: JellyfinRepository,
+    private val dao: VideoProgressDao,
+    private val now: () -> Long = System::currentTimeMillis,
+) {
+    /** Locally known in-progress titles, most recent first — the offline Continue watching source. */
+    fun observeLocal(limit: Int = CONTINUE_LIMIT): Flow<List<VideoItem>> =
+        dao.observeContinueWatching(limit).map { rows -> rows.map { it.toVideoItem() } }
+
+    /**
+     * The item to play for [itemId] and the position to start it at, merging the server's copy
+     * (authoritative metadata, may be unreachable) with the local row (always available).
+     */
+    suspend fun resolvePlayback(itemId: String): ResolvedPlayback {
+        val local = dao.findById(itemId)
+        val remote = runCatching { repository.videoItem(itemId) }.getOrNull()
+        return ResolvedPlayback(
+            item = remote ?: local?.toVideoItem(),
+            positionMs = resolveResumePosition(local, remote),
+        )
+    }
+
+    /**
+     * Record [positionMs] for [item] both locally and (best-effort) on the server.
+     *
+     * [runtimeMs] comes from the player rather than the metadata because a transcode's reported
+     * duration is what the position is actually measured against.
+     */
+    suspend fun record(
+        item: VideoItem,
+        positionMs: Long,
+        runtimeMs: Long,
+        event: VideoPlaybackEvent,
+        paused: Boolean = false,
+        transcoding: Boolean = false,
+    ) {
+        if (isFinished(positionMs, runtimeMs)) {
+            // Finished: drop it from Continue watching instead of stranding it at 99%.
+            dao.deleteById(item.id)
+        } else {
+            dao.upsert(item.toProgress(positionMs, runtimeMs, now()))
+        }
+        repository.reportVideoPlayback(item.id, positionMs, event, paused = paused, transcoding = transcoding)
+    }
+
+    /** Forget the local position for [itemId] (e.g. when its download is deleted). */
+    suspend fun clear(itemId: String) = dao.deleteById(itemId)
+
+    suspend fun clearAll() = dao.clear()
+
+    private companion object {
+        const val CONTINUE_LIMIT = 12
+    }
+}
+
+/** The item to play and where to start it, as resolved by [VideoProgressStore.resolvePlayback]. */
+data class ResolvedPlayback(val item: VideoItem?, val positionMs: Long)
+
+/**
+ * How much of the runtime must be watched before a title counts as finished. Matches Jellyfin's
+ * own threshold, so a title the server has already dropped from Continue Watching does not linger
+ * in ours.
+ */
+private const val FINISHED_FRACTION = 0.95f
+
+/** True once [positionMs] is far enough into [runtimeMs] that the title counts as watched. */
+internal fun isFinished(positionMs: Long, runtimeMs: Long): Boolean =
+    runtimeMs > 0L && positionMs >= runtimeMs * FINISHED_FRACTION
+
+/**
+ * The position to resume from given the [local] and [remote] records: whichever was written more
+ * recently wins.
+ *
+ * Taking the larger position instead would be wrong — a user who deliberately rewound on one
+ * device would be dragged forward again by the other side's stale, larger position.
+ */
+internal fun resolveResumePosition(local: VideoProgress?, remote: VideoItem?): Long = when {
+    local == null -> remote?.resumePositionMs ?: 0L
+    remote == null -> local.positionMs
+    remote.lastPlayedAtMs > local.updatedAtMs -> remote.resumePositionMs
+    else -> local.positionMs
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
@@ -12,6 +12,7 @@ import pe.net.libre.mixtapehaven.data.download.resolveLocalFirst
 import pe.net.libre.mixtapehaven.data.diagnostics.DiagnosticsLog
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
 import pe.net.libre.mixtapehaven.data.playback.PlayerController
+import pe.net.libre.mixtapehaven.data.playback.VideoProgressStore
 import pe.net.libre.mixtapehaven.data.session.SessionStore
 
 /** Manual dependency container holding app-scoped singletons. Created once in MixtapeApplication. */
@@ -40,9 +41,15 @@ class AppContainer(context: Context) {
     /**
      * Resolves ordered playable source URLs for a video item id. Defaults to remote streaming
      * (direct play, then HLS transcode); swap to serve local video downloads first, mirroring
-     * [PlayerController.streamUrlResolver] for audio.
+     * [PlayerController.streamUrlResolver] for audio. Suspending because building the transcode
+     * URL negotiates the media source id with the server.
      */
-    var videoSourceResolver: (String) -> List<String> = repository::videoStreamCandidates
+    var videoSourceResolver: suspend (String) -> List<String> = repository::videoStreamCandidates
+
+    /** Local + server watch positions for video, backing offline resume and Continue watching. */
+    val videoProgressStore: VideoProgressStore by lazy {
+        VideoProgressStore(repository, downloadDatabase.videoProgressDao())
+    }
 
     val downloadManager: DownloadManager by lazy {
         DownloadManager(

--- a/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/di/AppContainer.kt
@@ -48,7 +48,11 @@ class AppContainer(context: Context) {
 
     /** Local + server watch positions for video, backing offline resume and Continue watching. */
     val videoProgressStore: VideoProgressStore by lazy {
-        VideoProgressStore(repository, downloadDatabase.videoProgressDao())
+        VideoProgressStore(
+            repository = repository,
+            dao = downloadDatabase.videoProgressDao(),
+            downloadDao = downloadDatabase.videoDownloadDao(),
+        )
     }
 
     val downloadManager: DownloadManager by lazy {

--- a/app/src/main/java/pe/net/libre/mixtapehaven/model/VideoItem.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/model/VideoItem.kt
@@ -10,7 +10,7 @@ enum class VideoKind { MOVIE, SERIES, EPISODE }
  * portrait 2:3 poster for movies/series, but a 16:9 still for episodes (that is what Jellyfin
  * stores as an episode's primary). [backdropUrl] is the wide art; [artColor] is the tint fallback
  * when no artwork exists. [resumePositionMs] > 0 means the server has an in-progress watch
- * position for this user.
+ * position for this user, last updated at [lastPlayedAtMs] (epoch millis, 0 when never played).
  */
 data class VideoItem(
     val id: String,
@@ -24,6 +24,13 @@ data class VideoItem(
     val artColor: Color = Color(0xFF6C8A7A),
     val runtimeMs: Long = 0L,
     val resumePositionMs: Long = 0L,
+    val lastPlayedAtMs: Long = 0L,
     val seriesName: String? = null,
+    /** Parent series of an episode, for Next Up and autoplay lookups. Null for movies. */
+    val seriesId: String? = null,
     val seasonEpisodeLabel: String? = null,
-)
+) {
+    /** Fraction of the runtime already watched, in 0f..1f. 0 when the runtime is unknown. */
+    val progressFraction: Float
+        get() = if (runtimeMs <= 0L) 0f else (resumePositionMs.toFloat() / runtimeMs).coerceIn(0f, 1f)
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/ContinueCard.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/ContinueCard.kt
@@ -1,0 +1,150 @@
+package pe.net.libre.mixtapehaven.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.DownloadDone
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import pe.net.libre.mixtapehaven.data.jellyfin.formatTimeLeft
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
+import pe.net.libre.mixtapehaven.ui.theme.Accent
+import pe.net.libre.mixtapehaven.ui.theme.TextPrimary
+import pe.net.libre.mixtapehaven.ui.theme.TextSecondary
+
+/** Fixed card width from the "Continue Card" component in happypath.pen. */
+private val CARD_WIDTH = 184.dp
+
+/**
+ * A Continue watching card: a 16:9 still with a progress bar pinned to its bottom edge, the title,
+ * and a meta line ("S2 E4 · 23 min left"). [downloaded] shows the offline check beside the meta.
+ *
+ * Mirrors the "Continue Card" component in happypath.pen.
+ */
+@Composable
+fun ContinueCard(
+    video: VideoItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    downloaded: Boolean = false,
+) {
+    val meta = listOfNotNull(
+        video.seasonEpisodeLabel,
+        formatTimeLeft(video.runtimeMs, video.resumePositionMs).ifEmpty { null },
+    ).joinToString(" · ")
+    Column(
+        modifier = modifier.width(CARD_WIDTH).clickable(onClick = onClick),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ContinueStill(video)
+        Text(
+            video.title,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = TextPrimary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        if (meta.isNotEmpty()) {
+            ContinueMeta(meta = meta, downloaded = downloaded)
+        }
+    }
+}
+
+/** The 16:9 still with the watched-progress bar across its bottom edge. */
+@Composable
+private fun ContinueStill(video: VideoItem) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(16f / 9f)
+            .clip(RoundedCornerShape(14.dp))
+            .background(video.artColor),
+    ) {
+        // Episodes store a 16:9 still as their PRIMARY image, so the poster is the better crop for
+        // them; movies and series only have a wide image under backdropUrl.
+        val stillUrl = if (video.kind == VideoKind.EPISODE) {
+            video.posterUrl ?: video.backdropUrl
+        } else {
+            video.backdropUrl ?: video.posterUrl
+        }
+        if (stillUrl != null) {
+            AsyncImage(
+                model = stillUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        ProgressTrack(
+            fraction = video.progressFraction,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+/** The meta line under the title, optionally prefixed with the offline-copy check. */
+@Composable
+private fun ContinueMeta(meta: String, downloaded: Boolean) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        if (downloaded) {
+            Icon(
+                Icons.Outlined.DownloadDone,
+                contentDescription = "Downloaded",
+                tint = Accent,
+                modifier = Modifier.size(14.dp),
+            )
+        }
+        Text(
+            meta,
+            style = MaterialTheme.typography.bodySmall,
+            color = TextSecondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+/** The 3.dp watched-progress bar drawn across the bottom of a Continue watching still. */
+@Composable
+private fun ProgressTrack(fraction: Float, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(3.dp)
+            .background(Color.White.copy(alpha = 0.25f)),
+    ) {
+        Box(
+            Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(fraction.coerceIn(0f, 1f))
+                .background(Accent),
+        )
+    }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/ContinueCard.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/ContinueCard.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -57,7 +58,9 @@ fun ContinueCard(
         formatTimeLeft(video.runtimeMs, video.resumePositionMs).ifEmpty { null },
     ).joinToString(" · ")
     Column(
-        modifier = modifier.width(CARD_WIDTH).clickable(onClick = onClick),
+        modifier = modifier
+            .width(CARD_WIDTH)
+            .clickable(role = Role.Button, onClickLabel = "Resume ${video.title}", onClick = onClick),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         ContinueStill(video)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
@@ -8,7 +8,9 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import pe.net.libre.mixtapehaven.di.AppContainer
 import pe.net.libre.mixtapehaven.di.appContainer
 import pe.net.libre.mixtapehaven.ui.screens.downloads.DownloadsScreen
 import pe.net.libre.mixtapehaven.ui.screens.home.HomeScreen
@@ -64,8 +66,7 @@ fun MixtapeNavHost(startDestination: String, modifier: Modifier = Modifier) {
                 onBack = { navController.popBackStack() },
                 onOpenDownloads = { navController.navigate(Routes.DOWNLOADS) },
                 onSignOut = {
-                    container.playerController.stop()
-                    scope.launch { container.repository.signOut() }
+                    signOut(container, scope)
                     navController.navigate(Routes.LOGIN) {
                         popUpTo(0) { inclusive = true }
                     }
@@ -78,6 +79,20 @@ fun MixtapeNavHost(startDestination: String, modifier: Modifier = Modifier) {
                 onPlayVideo = { itemId -> navController.navigate(Routes.videoPlayer(itemId)) },
             )
         }
+    }
+}
+
+/**
+ * Stop playback and drop this user's session and local state.
+ *
+ * Watch positions are cleared too: they are per-user, so without this the next account to sign in
+ * would inherit the previous one's Continue watching rail.
+ */
+private fun signOut(container: AppContainer, scope: CoroutineScope) {
+    container.playerController.stop()
+    scope.launch {
+        container.videoProgressStore.clearAll()
+        container.repository.signOut()
     }
 }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
@@ -46,6 +46,7 @@ fun MixtapeNavHost(startDestination: String, modifier: Modifier = Modifier) {
                 onOpenDownloads = { navController.navigate(Routes.DOWNLOADS) },
                 onOpenNowPlaying = { navController.navigate(Routes.NOW_PLAYING) },
                 onOpenVideo = { itemId -> navController.navigate(Routes.videoDetail(itemId)) },
+                onResumeVideo = { itemId -> navController.navigate(Routes.videoPlayer(itemId)) },
             )
         }
         videoDestinations(navController)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -52,6 +52,7 @@ import pe.net.libre.mixtapehaven.model.Album
 import pe.net.libre.mixtapehaven.model.Track
 import pe.net.libre.mixtapehaven.model.VideoItem
 import pe.net.libre.mixtapehaven.ui.components.AlbumCard
+import pe.net.libre.mixtapehaven.ui.components.ContinueCard
 import pe.net.libre.mixtapehaven.ui.components.NowPlayingBar
 import pe.net.libre.mixtapehaven.ui.components.PosterCard
 import pe.net.libre.mixtapehaven.ui.components.RandomWalkCard
@@ -74,11 +75,10 @@ fun HomeScreen(
     onOpenDownloads: () -> Unit,
     onOpenNowPlaying: () -> Unit,
     onOpenVideo: (String) -> Unit,
+    onResumeVideo: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val viewModel = appViewModel {
-        HomeViewModel(it.repository, it.playerController, it.downloadManager, it.diagnosticsLog)
-    }
+    val viewModel = rememberHomeViewModel()
     val state by viewModel.state.collectAsState()
     val nowPlayingTrack by viewModel.nowPlaying.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
@@ -116,12 +116,15 @@ fun HomeScreen(
 
             HomeSections(
                 state = state,
-                onOpenDownloads = onOpenDownloads,
-                onOpenSettings = onOpenSettings,
-                onOpenVideo = onOpenVideo,
-                onPlayTrack = { viewModel.playOnDevice(it); onOpenNowPlaying() },
-                onPlayAlbum = { viewModel.playAlbum(it); onOpenNowPlaying() },
-                onRetry = viewModel::load,
+                actions = HomeSectionActions(
+                    onOpenDownloads = onOpenDownloads,
+                    onOpenSettings = onOpenSettings,
+                    onOpenVideo = onOpenVideo,
+                    onResumeVideo = onResumeVideo,
+                    onPlayTrack = { viewModel.playOnDevice(it); onOpenNowPlaying() },
+                    onPlayAlbum = { viewModel.playAlbum(it); onOpenNowPlaying() },
+                    onRetry = viewModel::load,
+                ),
             )
         }
 
@@ -167,47 +170,77 @@ private fun BoxScope.HomeOverlays(
     }
 }
 
-/** The library sections of Home: saved tracks, Movies & shows, and the Recently added grid. */
+/** Builds the Home ViewModel from the app container. */
+@Composable
+private fun rememberHomeViewModel(): HomeViewModel = appViewModel {
+    HomeViewModel(
+        it.repository,
+        it.playerController,
+        it.downloadManager,
+        it.videoDownloadManager,
+        it.videoProgressStore,
+        it.diagnosticsLog,
+    )
+}
+
+/** The callbacks [HomeSections] hands to its individual sections. */
+private data class HomeSectionActions(
+    val onOpenDownloads: () -> Unit,
+    val onOpenSettings: () -> Unit,
+    val onOpenVideo: (String) -> Unit,
+    val onResumeVideo: (String) -> Unit,
+    val onPlayTrack: (Track) -> Unit,
+    val onPlayAlbum: (Album) -> Unit,
+    val onRetry: () -> Unit,
+)
+
+/**
+ * The library sections of Home, in design order: saved tracks, Continue watching, Movies & shows,
+ * and the Recently added grid.
+ */
 @Composable
 private fun HomeSections(
     state: HomeViewModel.UiState,
-    onOpenDownloads: () -> Unit,
-    onOpenSettings: () -> Unit,
-    onOpenVideo: (String) -> Unit,
-    onPlayTrack: (Track) -> Unit,
-    onPlayAlbum: (Album) -> Unit,
-    onRetry: () -> Unit,
+    actions: HomeSectionActions,
 ) {
     if (state.onDevice.isNotEmpty()) {
         OnDeviceSection(
             tracks = state.onDevice,
-            onManage = onOpenDownloads,
-            onPlay = onPlayTrack,
+            onManage = actions.onOpenDownloads,
+            onPlay = actions.onPlayTrack,
+        )
+    }
+
+    if (state.continueWatching.isNotEmpty()) {
+        ContinueWatchingSection(
+            videos = state.continueWatching,
+            downloadedIds = state.downloadedVideoIds,
+            onVideoClick = { actions.onResumeVideo(it.id) },
         )
     }
 
     if (state.videos.isNotEmpty()) {
         MoviesAndShowsSection(
             videos = state.videos,
-            onVideoClick = { onOpenVideo(it.id) },
+            onVideoClick = { actions.onOpenVideo(it.id) },
         )
     }
 
     SectionHeader(
         title = "Recently added",
         actionLabel = "See all",
-        onAction = onOpenDownloads,
+        onAction = actions.onOpenDownloads,
     )
 
     when {
         state.albums.isNotEmpty() -> AlbumGrid(
             albums = state.albums,
-            onAlbumClick = onPlayAlbum,
+            onAlbumClick = actions.onPlayAlbum,
         )
         // Fetch in flight: render nothing rather than flash an empty state.
         state.loading -> Unit
-        state.error != null -> OfflineAlbumsState(onRetry = onRetry)
-        else -> FirstRunEmptyState(onOpenSettings = onOpenSettings)
+        state.error != null -> OfflineAlbumsState(onRetry = actions.onRetry)
+        else -> FirstRunEmptyState(onOpenSettings = actions.onOpenSettings)
     }
 }
 
@@ -271,6 +304,30 @@ private fun OnDeviceSection(
     Column {
         tracks.take(ON_DEVICE_PREVIEW).forEach { track ->
             TrackRow(track = track, onClick = { onPlay(track) })
+        }
+    }
+}
+
+/**
+ * Horizontal rail of partially-watched titles. Tapping one resumes it straight in the player
+ * rather than opening the detail screen — the whole point of the rail is skipping that hop.
+ *
+ * The plain title (no "See all") matches the design: the rail is the complete list.
+ */
+@Composable
+private fun ContinueWatchingSection(
+    videos: List<VideoItem>,
+    downloadedIds: Set<String>,
+    onVideoClick: (VideoItem) -> Unit,
+) {
+    SectionHeader(title = "Continue watching")
+    LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        items(videos, key = { it.id }) { video ->
+            ContinueCard(
+                video = video,
+                downloaded = video.id in downloadedIds,
+                onClick = { onVideoClick(video) },
+            )
         }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -115,9 +115,10 @@ class HomeViewModel(
             combine(
                 videoProgressStore.observeLocal(),
                 serverContinueWatching,
+                videoProgressStore.observeFinishedIds(),
                 videoDownloadManager.downloads,
-            ) { local, server, downloads ->
-                mergeContinueWatching(local, server) to
+            ) { local, server, finishedIds, downloads ->
+                mergeContinueWatching(local, server, finishedIds) to
                     downloads.filter { it.complete }.map { it.id }.toSet()
             }.collect { (merged, downloadedIds) ->
                 _state.update { it.copy(continueWatching = merged, downloadedVideoIds = downloadedIds) }
@@ -199,13 +200,19 @@ private const val CONTINUE_WATCHING_LIMIT = 12
  *
  * An id in both sides is kept once, taking whichever record was written later — the server knows
  * about other devices, the local table knows about offline viewing, and neither is reliably ahead.
+ *
+ * [finishedIds] are titles finished on this device. They are removed outright because the server
+ * snapshot is only refetched by a reload: without this, the episode just watched to the end would
+ * reappear in the rail as soon as its local row stopped counting as in-progress.
  */
 internal fun mergeContinueWatching(
     local: List<VideoItem>,
     server: List<VideoItem>,
+    finishedIds: Set<String> = emptySet(),
 ): List<VideoItem> = (local + server)
+    .filterNot { it.id in finishedIds }
     .groupBy { it.id }
-    .map { (_, records) -> records.maxBy { it.lastPlayedAtMs } }
+    .mapNotNull { (_, records) -> records.maxByOrNull { it.lastPlayedAtMs } }
     .filter { it.resumePositionMs > 0 }
     .sortedByDescending { it.lastPlayedAtMs }
     .take(CONTINUE_WATCHING_LIMIT)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
@@ -18,11 +19,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import pe.net.libre.mixtapehaven.data.diagnostics.DiagnosticsLog
 import pe.net.libre.mixtapehaven.data.download.DownloadManager
+import pe.net.libre.mixtapehaven.data.download.VideoDownloadManager
 import pe.net.libre.mixtapehaven.data.download.toTrack
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
 import pe.net.libre.mixtapehaven.data.playback.PlaybackSource
 import pe.net.libre.mixtapehaven.data.playback.PlayerController
 import pe.net.libre.mixtapehaven.data.playback.RandomWalk
+import pe.net.libre.mixtapehaven.data.playback.VideoProgressStore
 import pe.net.libre.mixtapehaven.model.Album
 import pe.net.libre.mixtapehaven.model.Track
 import pe.net.libre.mixtapehaven.model.VideoItem
@@ -31,6 +34,8 @@ class HomeViewModel(
     private val repository: JellyfinRepository,
     private val playerController: PlayerController,
     private val downloadManager: DownloadManager,
+    private val videoDownloadManager: VideoDownloadManager,
+    private val videoProgressStore: VideoProgressStore,
     private val diagnostics: DiagnosticsLog,
 ) : ViewModel() {
 
@@ -38,6 +43,10 @@ class HomeViewModel(
         val userName: String = "",
         val albums: List<Album> = emptyList(),
         val videos: List<VideoItem> = emptyList(),
+        /** Partially-watched movies/episodes for the Continue watching rail. */
+        val continueWatching: List<VideoItem> = emptyList(),
+        /** Ids with a completed offline copy, for the Continue card's download check. */
+        val downloadedVideoIds: Set<String> = emptySet(),
         val onDevice: List<Track> = emptyList(),
         val loading: Boolean = true,
         val error: String? = null,
@@ -50,6 +59,9 @@ class HomeViewModel(
     val nowPlaying: StateFlow<Track?> = playerController.nowPlaying
     val isPlaying: StateFlow<Boolean> = playerController.isPlaying
 
+    /** Last successful server Continue Watching fetch; empty until [load] completes or when offline. */
+    private val serverContinueWatching = MutableStateFlow<List<VideoItem>>(emptyList())
+
     private val _snackbarMessages = Channel<String>(Channel.BUFFERED)
 
     /** One-shot messages for transient UI feedback (e.g. a Snackbar), not persisted in [state]. */
@@ -58,6 +70,7 @@ class HomeViewModel(
     init {
         load()
         observeDownloads()
+        observeContinueWatching()
     }
 
     fun load() {
@@ -68,8 +81,12 @@ class HomeViewModel(
             // music Home, so videos degrade to an empty (hidden) section independently — and load
             // in parallel so the new section adds no latency to the album fetch.
             val videosDeferred = async { runCatching { repository.moviesAndShows() }.getOrDefault(emptyList()) }
+            // Offline this fails and the rail falls back to the local table, so keep the last
+            // known server list rather than clearing it.
+            val continueDeferred = async { runCatching { repository.continueWatching() }.getOrNull() }
             val albumsResult = runCatching { repository.recentlyAddedAlbums() }
             val videos = videosDeferred.await()
+            continueDeferred.await()?.let { serverContinueWatching.value = it }
             albumsResult.fold(
                 onSuccess = { albums ->
                     _state.update { it.copy(userName = userName, albums = albums, videos = videos, loading = false) }
@@ -85,6 +102,26 @@ class HomeViewModel(
                     }
                 },
             )
+        }
+    }
+
+    /**
+     * Keep the Continue watching rail in sync. The local table is the base (it is the only source
+     * that works offline); the server's list is layered on top when reachable so progress made on
+     * other devices shows up too.
+     */
+    private fun observeContinueWatching() {
+        viewModelScope.launch {
+            combine(
+                videoProgressStore.observeLocal(),
+                serverContinueWatching,
+                videoDownloadManager.downloads,
+            ) { local, server, downloads ->
+                mergeContinueWatching(local, server) to
+                    downloads.filter { it.complete }.map { it.id }.toSet()
+            }.collect { (merged, downloadedIds) ->
+                _state.update { it.copy(continueWatching = merged, downloadedVideoIds = downloadedIds) }
+            }
         }
     }
 
@@ -152,3 +189,23 @@ class HomeViewModel(
         const val TAG = "HomeViewModel"
     }
 }
+
+/** How many titles the Continue watching rail shows. */
+private const val CONTINUE_WATCHING_LIMIT = 12
+
+/**
+ * Merge the [local] and [server] Continue watching lists into one rail, most recently watched
+ * first.
+ *
+ * An id in both sides is kept once, taking whichever record was written later — the server knows
+ * about other devices, the local table knows about offline viewing, and neither is reliably ahead.
+ */
+internal fun mergeContinueWatching(
+    local: List<VideoItem>,
+    server: List<VideoItem>,
+): List<VideoItem> = (local + server)
+    .groupBy { it.id }
+    .map { (_, records) -> records.maxBy { it.lastPlayedAtMs } }
+    .filter { it.resumePositionMs > 0 }
+    .sortedByDescending { it.lastPlayedAtMs }
+    .take(CONTINUE_WATCHING_LIMIT)

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoDetailViewModel.kt
@@ -34,6 +34,8 @@ class VideoDetailViewModel(
     data class UiState(
         val item: VideoItem? = null,
         val episodes: List<VideoItem> = emptyList(),
+        /** For a series, the server's Next Up episode — what the Play button starts. */
+        val nextUp: VideoItem? = null,
         val loading: Boolean = true,
         val error: String? = null,
     )
@@ -61,11 +63,17 @@ class VideoDetailViewModel(
         viewModelScope.launch {
             runCatching {
                 val item = requireNotNull(repository.videoItem(itemId)) { "Item not found" }
-                val episodes = if (item.kind == VideoKind.SERIES) repository.seriesEpisodes(itemId) else emptyList()
-                item to episodes
+                val series = item.kind == VideoKind.SERIES
+                val episodes = if (series) repository.seriesEpisodes(itemId) else emptyList()
+                // Next Up is advisory: a server that cannot answer falls back to the episode scan
+                // in selectPlayTarget rather than failing the whole screen.
+                val nextUp = if (series) runCatching { repository.nextUpEpisode(itemId) }.getOrNull() else null
+                Triple(item, episodes, nextUp)
             }.fold(
-                onSuccess = { (item, episodes) ->
-                    _state.update { it.copy(item = item, episodes = episodes, loading = false) }
+                onSuccess = { (item, episodes, nextUp) ->
+                    _state.update {
+                        it.copy(item = item, episodes = episodes, nextUp = nextUp, loading = false)
+                    }
                 },
                 onFailure = { error ->
                     _state.update { it.copy(loading = false, error = error.message ?: "Could not load this title") }
@@ -75,7 +83,8 @@ class VideoDetailViewModel(
     }
 
     /** See [selectPlayTarget]. Null while loading or on error. */
-    fun playTarget(): VideoItem? = selectPlayTarget(_state.value.item, _state.value.episodes)
+    fun playTarget(): VideoItem? =
+        selectPlayTarget(_state.value.item, _state.value.episodes, _state.value.nextUp)
 
     fun download(item: VideoItem) = downloadManager.download(item)
 
@@ -90,15 +99,21 @@ class VideoDetailViewModel(
 }
 
 /**
- * The item playback should start with: the movie/episode itself, or for a series the first
- * in-progress episode, falling back to the first episode.
+ * The item playback should start with: the movie/episode itself, or for a series the server's
+ * [nextUp] episode.
  *
- * Known limitation: once an episode is watched to completion Jellyfin zeroes its position, so a
- * user who finished E1 (with nothing in progress) is sent to E1 again instead of E2. Switching to
- * tvShowsApi.getNextUp would solve exactly this.
+ * Next Up is what makes "finished E1, press Play" land on E2: Jellyfin zeroes an episode's
+ * position once it is watched, so the local fallback below — first in-progress episode, else the
+ * first episode — would send that user back to E1. The fallback only runs when the server could
+ * not answer (offline, or an older server), where being off by one beats not playing at all.
  */
-internal fun selectPlayTarget(item: VideoItem?, episodes: List<VideoItem>): VideoItem? = when {
+internal fun selectPlayTarget(
+    item: VideoItem?,
+    episodes: List<VideoItem>,
+    nextUp: VideoItem? = null,
+): VideoItem? = when {
     item == null -> null
     item.kind != VideoKind.SERIES -> item
+    nextUp != null -> nextUp
     else -> episodes.firstOrNull { it.resumePositionMs > 0 } ?: episodes.firstOrNull()
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
@@ -2,13 +2,16 @@ package pe.net.libre.mixtapehaven.ui.screens.video
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -45,9 +48,17 @@ fun VideoPlayerScreen(
 ) {
     val appContext = LocalContext.current.applicationContext
     val viewModel = appViewModel {
-        VideoPlayerViewModel(appContext, it.repository, it.playerController, itemId, it.videoSourceResolver)
+        VideoPlayerViewModel(
+            appContext,
+            it.repository,
+            it.videoProgressStore,
+            it.playerController,
+            itemId,
+            it.videoSourceResolver,
+        )
     }
     val error by viewModel.error.collectAsState()
+    val upNext by viewModel.upNext.collectAsState()
 
     // No background video service exists, so pause when the screen stops (Home button, lock);
     // otherwise audio would keep playing invisibly and the progress loop would churn the radio.
@@ -84,22 +95,66 @@ fun VideoPlayerScreen(
             )
         }
 
-        Box(
-            modifier = Modifier
-                .statusBarsPadding()
-                .padding(12.dp)
-                .size(40.dp)
-                .clip(CircleShape)
-                .background(Color.Black.copy(alpha = 0.45f))
-                .clickable(role = Role.Button, onClick = onBack),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                Icons.Outlined.ArrowBack,
-                contentDescription = "Back",
-                tint = TextPrimary,
-                modifier = Modifier.size(22.dp),
+        BackButton(onBack = onBack, modifier = Modifier.align(Alignment.TopStart))
+
+        upNext?.let { next ->
+            NextEpisodePill(
+                label = next.seasonEpisodeLabel ?: "Next episode",
+                onClick = viewModel::playNext,
+                modifier = Modifier.align(Alignment.TopEnd),
             )
         }
+    }
+}
+
+/** Circular back affordance over the video surface, which has no system chrome of its own. */
+@Composable
+private fun BackButton(onBack: () -> Unit, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .statusBarsPadding()
+            .padding(12.dp)
+            .size(40.dp)
+            .clip(CircleShape)
+            .background(Color.Black.copy(alpha = 0.45f))
+            .clickable(role = Role.Button, onClick = onBack),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            Icons.Outlined.ArrowBack,
+            contentDescription = "Back",
+            tint = TextPrimary,
+            modifier = Modifier.size(22.dp),
+        )
+    }
+}
+
+/**
+ * Skip-to-next-episode pill.
+ *
+ * A dedicated control rather than PlayerView's next button: the player holds a single MediaItem at
+ * a time (each episode negotiates its own stream), so the built-in next would render permanently
+ * disabled.
+ */
+@Composable
+private fun NextEpisodePill(label: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .statusBarsPadding()
+            .padding(12.dp)
+            .clip(CircleShape)
+            .background(Color.Black.copy(alpha = 0.45f))
+            .clickable(role = Role.Button, onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(label, style = MaterialTheme.typography.bodySmall, color = TextPrimary)
+        Icon(
+            Icons.Filled.SkipNext,
+            contentDescription = "Play next episode",
+            tint = TextPrimary,
+            modifier = Modifier.size(18.dp),
+        )
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
@@ -22,21 +22,26 @@ import kotlinx.coroutines.launch
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
 import pe.net.libre.mixtapehaven.data.jellyfin.VideoPlaybackEvent
 import pe.net.libre.mixtapehaven.data.playback.PlayerController
+import pe.net.libre.mixtapehaven.data.playback.VideoProgressStore
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
 
 /**
  * Owns the video [player] (a separate ExoPlayer instance from the music stack) so playback
- * survives configuration changes. Pauses music on start, resumes from the server-side position,
- * and reports start/progress/stopped back to Jellyfin so Continue Watching stays in sync.
+ * survives configuration changes. Pauses music on start, resumes from the last known position
+ * (local or server, whichever is fresher), and records progress through [progressStore].
  *
  * Stream sources come from [resolveSources] as ordered candidates (direct play first, HLS
  * transcode fallback); a playback error falls through to the next candidate at the same position.
+ * When an episode ends the next one in the season starts automatically.
  */
 class VideoPlayerViewModel(
     context: Context,
     private val repository: JellyfinRepository,
+    private val progressStore: VideoProgressStore,
     musicController: PlayerController,
-    private val itemId: String,
-    private val resolveSources: (String) -> List<String>,
+    itemId: String,
+    private val resolveSources: suspend (String) -> List<String>,
 ) : ViewModel() {
 
     val player: ExoPlayer = ExoPlayer.Builder(context.applicationContext)
@@ -54,6 +59,14 @@ class VideoPlayerViewModel(
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
 
+    /** The item currently on screen; changes when autoplay advances to the next episode. */
+    private val _nowPlaying = MutableStateFlow<VideoItem?>(null)
+    val nowPlaying: StateFlow<VideoItem?> = _nowPlaying.asStateFlow()
+
+    /** The episode autoplay will roll into, if any — also drives the player's next button. */
+    private val _upNext = MutableStateFlow<VideoItem?>(null)
+    val upNext: StateFlow<VideoItem?> = _upNext.asStateFlow()
+
     private var candidates: List<String> = emptyList()
     private var candidateIndex = 0
 
@@ -62,7 +75,11 @@ class VideoPlayerViewModel(
 
     private val listener = object : Player.Listener {
         override fun onPlaybackStateChanged(playbackState: Int) {
-            if (playbackState == Player.STATE_READY) reachedReady = true
+            when (playbackState) {
+                Player.STATE_READY -> reachedReady = true
+                Player.STATE_ENDED -> onPlaybackEnded()
+                else -> Unit
+            }
         }
 
         override fun onPlayerError(error: PlaybackException) {
@@ -84,16 +101,83 @@ class VideoPlayerViewModel(
         player.addListener(listener)
         player.playWhenReady = true
         viewModelScope.launch {
-            val resumeMs = runCatching { repository.videoItem(itemId) }
-                .getOrNull()?.resumePositionMs ?: 0L
-            candidates = resolveSources(itemId)
-            if (candidates.isEmpty()) {
-                _error.value = "No playable source for this title"
-                return@launch
-            }
-            prepareCurrentCandidate(startMs = resumeMs)
-            repository.reportVideoPlayback(itemId, resumeMs, VideoPlaybackEvent.STARTED)
+            startItem(itemId)
             reportProgressLoop()
+        }
+    }
+
+    /** Load [id], resume it, and begin playing. Used for the initial item and each autoplay hop. */
+    private suspend fun startItem(id: String) {
+        val resolved = progressStore.resolvePlayback(id)
+        val item = resolved.item
+        if (item == null) {
+            _error.value = "Could not load this title"
+            return
+        }
+        _nowPlaying.value = item
+        candidates = resolveSources(id)
+        candidateIndex = 0
+        reachedReady = false
+        if (candidates.isEmpty()) {
+            _error.value = "No playable source for this title"
+            return
+        }
+        _error.value = null
+        prepareCurrentCandidate(startMs = resolved.positionMs)
+        progressStore.record(item, resolved.positionMs, player.duration.orZero(), VideoPlaybackEvent.STARTED)
+        _upNext.value = loadUpNext(item)
+    }
+
+    /**
+     * The episode following [item] in its season, or null for movies, the last episode, or when the
+     * series listing is unreachable.
+     *
+     * Deliberately positional rather than the server's Next Up: autoplay should roll into the
+     * literal next episode, whereas Next Up answers the different question of where to resume a
+     * series (see [VideoDetailViewModel]).
+     */
+    private suspend fun loadUpNext(item: VideoItem): VideoItem? {
+        val seriesId = item.seriesId?.takeIf { item.kind == VideoKind.EPISODE } ?: return null
+        val episodes = runCatching { repository.seriesEpisodes(seriesId) }.getOrNull().orEmpty()
+        val index = episodes.indexOfFirst { it.id == item.id }
+        return if (index >= 0) episodes.getOrNull(index + 1) else null
+    }
+
+    /** Advance to the next episode, or leave the finished frame up when there is nothing to play. */
+    private fun onPlaybackEnded() {
+        val finished = _nowPlaying.value ?: return
+        val next = _upNext.value
+        viewModelScope.launch {
+            // Finalize the finished item first so it leaves Continue watching before the next
+            // episode's own STARTED report lands.
+            progressStore.record(
+                finished,
+                player.duration.orZero(),
+                player.duration.orZero(),
+                VideoPlaybackEvent.STOPPED,
+                transcoding = candidateIndex > 0,
+            )
+            if (next != null) startItem(next.id)
+        }
+    }
+
+    /** Skip to the next episode on user request, finalizing the current one as partially watched. */
+    fun playNext() {
+        val next = _upNext.value ?: return
+        val current = _nowPlaying.value
+        val positionMs = player.currentPosition.coerceAtLeast(0)
+        val durationMs = player.duration.orZero()
+        viewModelScope.launch {
+            if (current != null) {
+                progressStore.record(
+                    current,
+                    positionMs,
+                    durationMs,
+                    VideoPlaybackEvent.STOPPED,
+                    transcoding = candidateIndex > 0,
+                )
+            }
+            startItem(next.id)
         }
     }
 
@@ -125,9 +209,11 @@ class VideoPlayerViewModel(
     }
 
     private suspend fun reportProgress(paused: Boolean) {
-        repository.reportVideoPlayback(
-            itemId,
-            player.currentPosition,
+        val item = _nowPlaying.value ?: return
+        progressStore.record(
+            item,
+            player.currentPosition.coerceAtLeast(0),
+            player.duration.orZero(),
             VideoPlaybackEvent.PROGRESS,
             paused = paused,
             transcoding = candidateIndex > 0,
@@ -140,20 +226,23 @@ class VideoPlayerViewModel(
     }
 
     override fun onCleared() {
+        val item = _nowPlaying.value
         val positionMs = player.currentPosition.coerceAtLeast(0)
+        val durationMs = player.duration.orZero()
         val playedSomething = reachedReady
         val transcoding = candidateIndex > 0
         player.removeListener(listener)
         player.release()
         // A session that never played must not report STOPPED: its position 0 would regress the
-        // server-side resume point of a half-watched item.
-        if (!playedSomething) return
-        // viewModelScope is already cancelled here, so the final report (which fixes the server's
-        // resume point) needs its own short-lived scope.
+        // resume point of a half-watched item.
+        if (!playedSomething || item == null) return
+        // viewModelScope is already cancelled here, so the final write (which fixes the resume
+        // point) needs its own short-lived scope.
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
-            repository.reportVideoPlayback(
-                itemId,
+            progressStore.record(
+                item,
                 positionMs,
+                durationMs,
                 VideoPlaybackEvent.STOPPED,
                 transcoding = transcoding,
             )
@@ -164,3 +253,6 @@ class VideoPlayerViewModel(
         const val PROGRESS_REPORT_MS = 10_000L
     }
 }
+
+/** ExoPlayer reports an unknown duration as [C.TIME_UNSET]; treat that as "not known yet". */
+private fun Long.orZero(): Long = if (this == C.TIME_UNSET || this < 0L) 0L else this

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
@@ -108,6 +108,9 @@ class VideoPlayerViewModel(
 
     /** Load [id], resume it, and begin playing. Used for the initial item and each autoplay hop. */
     private suspend fun startItem(id: String) {
+        // Cleared up front so a hop that fails below cannot leave the pill pointing at the
+        // previous episode's successor, and so it never shows a stale value while loadUpNext runs.
+        _upNext.value = null
         val resolved = progressStore.resolvePlayback(id)
         val item = resolved.item
         if (item == null) {
@@ -124,7 +127,7 @@ class VideoPlayerViewModel(
         }
         _error.value = null
         prepareCurrentCandidate(startMs = resolved.positionMs)
-        progressStore.record(item, resolved.positionMs, player.duration.orZero(), VideoPlaybackEvent.STARTED)
+        progressStore.record(item, resolved.positionMs, player.duration.durationOrZero(), VideoPlaybackEvent.STARTED)
         _upNext.value = loadUpNext(item)
     }
 
@@ -152,8 +155,8 @@ class VideoPlayerViewModel(
             // episode's own STARTED report lands.
             progressStore.record(
                 finished,
-                player.duration.orZero(),
-                player.duration.orZero(),
+                player.duration.durationOrZero(),
+                player.duration.durationOrZero(),
                 VideoPlaybackEvent.STOPPED,
                 transcoding = candidateIndex > 0,
             )
@@ -166,7 +169,7 @@ class VideoPlayerViewModel(
         val next = _upNext.value ?: return
         val current = _nowPlaying.value
         val positionMs = player.currentPosition.coerceAtLeast(0)
-        val durationMs = player.duration.orZero()
+        val durationMs = player.duration.durationOrZero()
         viewModelScope.launch {
             if (current != null) {
                 progressStore.record(
@@ -213,7 +216,7 @@ class VideoPlayerViewModel(
         progressStore.record(
             item,
             player.currentPosition.coerceAtLeast(0),
-            player.duration.orZero(),
+            player.duration.durationOrZero(),
             VideoPlaybackEvent.PROGRESS,
             paused = paused,
             transcoding = candidateIndex > 0,
@@ -228,7 +231,7 @@ class VideoPlayerViewModel(
     override fun onCleared() {
         val item = _nowPlaying.value
         val positionMs = player.currentPosition.coerceAtLeast(0)
-        val durationMs = player.duration.orZero()
+        val durationMs = player.duration.durationOrZero()
         val playedSomething = reachedReady
         val transcoding = candidateIndex > 0
         player.removeListener(listener)
@@ -255,4 +258,4 @@ class VideoPlayerViewModel(
 }
 
 /** ExoPlayer reports an unknown duration as [C.TIME_UNSET]; treat that as "not known yet". */
-private fun Long.orZero(): Long = if (this == C.TIME_UNSET || this < 0L) 0L else this
+private fun Long.durationOrZero(): Long = if (this == C.TIME_UNSET || this < 0L) 0L else this

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinVideoMappingTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/jellyfin/JellyfinVideoMappingTest.kt
@@ -27,4 +27,26 @@ class JellyfinVideoMappingTest {
     fun `videoColorFor is deterministic per key`() {
         assertEquals(videoColorFor("abc"), videoColorFor("abc"))
     }
+
+    @Test
+    fun `formatTimeLeft renders minutes under an hour`() {
+        assertEquals("23 min left", formatTimeLeft(runtimeMs = 60 * 60_000L, positionMs = 37 * 60_000L))
+    }
+
+    @Test
+    fun `formatTimeLeft renders hours and minutes`() {
+        assertEquals("1h 12m left", formatTimeLeft(runtimeMs = 120 * 60_000L, positionMs = 48 * 60_000L))
+    }
+
+    /** Under a minute left reads as finished, so the card drops the segment rather than saying "0 min". */
+    @Test
+    fun `formatTimeLeft is empty near the end`() {
+        assertEquals("", formatTimeLeft(runtimeMs = 60 * 60_000L, positionMs = 60 * 60_000L))
+        assertEquals("", formatTimeLeft(runtimeMs = 60 * 60_000L, positionMs = 59 * 60_000L + 30_000L))
+    }
+
+    @Test
+    fun `formatTimeLeft is empty for an unknown runtime`() {
+        assertEquals("", formatTimeLeft(runtimeMs = 0, positionMs = 0))
+    }
 }

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/VideoProgressStoreTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/VideoProgressStoreTest.kt
@@ -5,6 +5,8 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import pe.net.libre.mixtapehaven.data.download.VideoProgress
+import pe.net.libre.mixtapehaven.data.download.toProgress
+import pe.net.libre.mixtapehaven.data.download.toVideoItem
 import pe.net.libre.mixtapehaven.model.VideoItem
 import pe.net.libre.mixtapehaven.model.VideoKind
 
@@ -19,6 +21,7 @@ class VideoProgressStoreTest {
         title = "Title",
         kind = VideoKind.MOVIE.name,
         seriesName = null,
+        seriesId = null,
         seasonEpisodeLabel = null,
         posterUrl = null,
         backdropUrl = null,
@@ -106,6 +109,26 @@ class VideoProgressStoreTest {
     @Test
     fun `an unknown runtime is never finished`() {
         assertFalse(isFinished(positionMs = 600_000, runtimeMs = 0))
+    }
+
+    /** An episode resumed from a local row must keep its series, or autoplay dies offline. */
+    @Test
+    fun `a local row round-trips the series id`() {
+        val episode = VideoItem(
+            id = "e1",
+            title = "Episode",
+            kind = VideoKind.EPISODE,
+            runtimeMs = HOUR_MS,
+            seriesName = "Show",
+            seriesId = "series-1",
+            seasonEpisodeLabel = "S3 E2",
+        )
+
+        val restored = episode.toProgress(positionMs = 60_000, runtimeMs = HOUR_MS, nowMs = 1_000).toVideoItem()
+
+        assertEquals("series-1", restored.seriesId)
+        assertEquals(VideoKind.EPISODE, restored.kind)
+        assertEquals("S3 E2", restored.seasonEpisodeLabel)
     }
 
     private companion object {

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/VideoProgressStoreTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/VideoProgressStoreTest.kt
@@ -1,0 +1,114 @@
+package pe.net.libre.mixtapehaven.data.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import pe.net.libre.mixtapehaven.data.download.VideoProgress
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
+
+/** Unit coverage for the local/server resume arbitration behind offline video playback. */
+class VideoProgressStoreTest {
+
+    private fun local(positionMs: Long, updatedAtMs: Long) = VideoProgress(
+        id = "v1",
+        positionMs = positionMs,
+        runtimeMs = HOUR_MS,
+        updatedAtMs = updatedAtMs,
+        title = "Title",
+        kind = VideoKind.MOVIE.name,
+        seriesName = null,
+        seasonEpisodeLabel = null,
+        posterUrl = null,
+        backdropUrl = null,
+        artColorArgb = 0,
+    )
+
+    private fun remote(positionMs: Long, lastPlayedAtMs: Long) = VideoItem(
+        id = "v1",
+        title = "Title",
+        kind = VideoKind.MOVIE,
+        runtimeMs = HOUR_MS,
+        resumePositionMs = positionMs,
+        lastPlayedAtMs = lastPlayedAtMs,
+    )
+
+    @Test
+    fun `no records resume from the start`() {
+        assertEquals(0L, resolveResumePosition(null, null))
+    }
+
+    @Test
+    fun `only a server record uses the server position`() {
+        assertEquals(5_000L, resolveResumePosition(null, remote(5_000, lastPlayedAtMs = 100)))
+    }
+
+    @Test
+    fun `only a local record uses the local position`() {
+        assertEquals(7_000L, resolveResumePosition(local(7_000, updatedAtMs = 100), null))
+    }
+
+    /** Watching offline then reopening: the local write is newer, so it must not be overwritten. */
+    @Test
+    fun `the fresher local record wins over a stale server position`() {
+        val resolved = resolveResumePosition(
+            local(600_000, updatedAtMs = 2_000),
+            remote(60_000, lastPlayedAtMs = 1_000),
+        )
+
+        assertEquals(600_000L, resolved)
+    }
+
+    /** Watching on another device: the server is newer even though its position is smaller. */
+    @Test
+    fun `the fresher server record wins even when its position is smaller`() {
+        val resolved = resolveResumePosition(
+            local(600_000, updatedAtMs = 1_000),
+            remote(60_000, lastPlayedAtMs = 2_000),
+        )
+
+        assertEquals(60_000L, resolved)
+    }
+
+    /** A deliberate rewind must stick — taking the maximum position would undo it. */
+    @Test
+    fun `a rewind on the fresher side is preserved`() {
+        val resolved = resolveResumePosition(
+            local(30_000, updatedAtMs = 5_000),
+            remote(1_800_000, lastPlayedAtMs = 4_000),
+        )
+
+        assertEquals(30_000L, resolved)
+    }
+
+    @Test
+    fun `equal timestamps prefer the local record`() {
+        val resolved = resolveResumePosition(
+            local(30_000, updatedAtMs = 1_000),
+            remote(90_000, lastPlayedAtMs = 1_000),
+        )
+
+        assertEquals(30_000L, resolved)
+    }
+
+    @Test
+    fun `a title watched past the threshold counts as finished`() {
+        assertTrue(isFinished(positionMs = (HOUR_MS * 0.96).toLong(), runtimeMs = HOUR_MS))
+    }
+
+    @Test
+    fun `a partially watched title is not finished`() {
+        assertFalse(isFinished(positionMs = HOUR_MS / 2, runtimeMs = HOUR_MS))
+    }
+
+    /** An unknown duration (a still-loading transcode) must never mark a title watched. */
+    @Test
+    fun `an unknown runtime is never finished`() {
+        assertFalse(isFinished(positionMs = 600_000, runtimeMs = 0))
+    }
+
+    private companion object {
+        const val HOUR_MS = 3_600_000L
+    }
+}

--- a/app/src/test/java/pe/net/libre/mixtapehaven/ui/screens/home/ContinueWatchingMergeTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/ui/screens/home/ContinueWatchingMergeTest.kt
@@ -72,6 +72,21 @@ class ContinueWatchingMergeTest {
         assertEquals(listOf("b"), merged.map { it.id })
     }
 
+    /**
+     * The regression this guards: the server snapshot still lists a just-finished title as in
+     * progress, and it is only refetched on reload.
+     */
+    @Test
+    fun `a locally finished title is suppressed from a stale server list`() {
+        val merged = mergeContinueWatching(
+            local = emptyList(),
+            server = listOf(item("a", 60_000, 100), item("b", 60_000, 200)),
+            finishedIds = setOf("a"),
+        )
+
+        assertEquals(listOf("b"), merged.map { it.id })
+    }
+
     @Test
     fun `the rail is capped`() {
         val many = (1..40).map { item("v$it", 60_000, it.toLong()) }

--- a/app/src/test/java/pe/net/libre/mixtapehaven/ui/screens/home/ContinueWatchingMergeTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/ui/screens/home/ContinueWatchingMergeTest.kt
@@ -1,0 +1,81 @@
+package pe.net.libre.mixtapehaven.ui.screens.home
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import pe.net.libre.mixtapehaven.model.VideoItem
+import pe.net.libre.mixtapehaven.model.VideoKind
+
+/** Unit coverage for merging the local and server Continue watching lists into one rail. */
+class ContinueWatchingMergeTest {
+
+    private fun item(id: String, positionMs: Long, lastPlayedAtMs: Long, title: String = id) = VideoItem(
+        id = id,
+        title = title,
+        kind = VideoKind.MOVIE,
+        runtimeMs = 3_600_000L,
+        resumePositionMs = positionMs,
+        lastPlayedAtMs = lastPlayedAtMs,
+    )
+
+    @Test
+    fun `empty sides merge to nothing`() {
+        assertTrue(mergeContinueWatching(emptyList(), emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `local-only titles survive so the rail works offline`() {
+        val merged = mergeContinueWatching(listOf(item("a", 60_000, 100)), emptyList())
+
+        assertEquals(listOf("a"), merged.map { it.id })
+    }
+
+    @Test
+    fun `titles are ordered by most recently watched`() {
+        val merged = mergeContinueWatching(
+            local = listOf(item("a", 60_000, 100)),
+            server = listOf(item("b", 60_000, 300), item("c", 60_000, 200)),
+        )
+
+        assertEquals(listOf("b", "c", "a"), merged.map { it.id })
+    }
+
+    @Test
+    fun `a title on both sides appears once`() {
+        val merged = mergeContinueWatching(
+            local = listOf(item("a", 60_000, 100)),
+            server = listOf(item("a", 90_000, 200)),
+        )
+
+        assertEquals(1, merged.size)
+    }
+
+    @Test
+    fun `the fresher record wins for a title on both sides`() {
+        val merged = mergeContinueWatching(
+            local = listOf(item("a", 600_000, 500, title = "local")),
+            server = listOf(item("a", 90_000, 200, title = "server")),
+        )
+
+        assertEquals("local", merged.single().title)
+        assertEquals(600_000L, merged.single().resumePositionMs)
+    }
+
+    /** A finished title reported with a zeroed position must not linger in the rail. */
+    @Test
+    fun `titles with no position are dropped`() {
+        val merged = mergeContinueWatching(
+            local = listOf(item("a", 0, 100)),
+            server = listOf(item("b", 60_000, 200)),
+        )
+
+        assertEquals(listOf("b"), merged.map { it.id })
+    }
+
+    @Test
+    fun `the rail is capped`() {
+        val many = (1..40).map { item("v$it", 60_000, it.toLong()) }
+
+        assertEquals(12, mergeContinueWatching(many, emptyList()).size)
+    }
+}

--- a/app/src/test/java/pe/net/libre/mixtapehaven/ui/screens/video/SelectPlayTargetTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/ui/screens/video/SelectPlayTargetTest.kt
@@ -48,4 +48,32 @@ class SelectPlayTargetTest {
     fun `series without episodes yields no target`() {
         assertNull(selectPlayTarget(video("s", VideoKind.SERIES), emptyList()))
     }
+
+    @Test
+    fun `series prefers the server's next up over the episode scan`() {
+        val series = video("s", VideoKind.SERIES)
+        val episodes = listOf(
+            video("e1", VideoKind.EPISODE, resumeMs = 60_000),
+            video("e2", VideoKind.EPISODE),
+        )
+
+        assertEquals("e2", selectPlayTarget(series, episodes, nextUp = video("e2", VideoKind.EPISODE))?.id)
+    }
+
+    /** The regression this fixes: a finished E1 has no position, so the scan would replay it. */
+    @Test
+    fun `series after finishing an episode plays the following one`() {
+        val series = video("s", VideoKind.SERIES)
+        // Jellyfin zeroes a watched episode's position, so nothing here looks in progress.
+        val episodes = listOf(video("e1", VideoKind.EPISODE), video("e2", VideoKind.EPISODE))
+
+        assertEquals("e2", selectPlayTarget(series, episodes, nextUp = video("e2", VideoKind.EPISODE))?.id)
+    }
+
+    @Test
+    fun `next up is ignored for a movie`() {
+        val movie = video("m", VideoKind.MOVIE)
+
+        assertEquals(movie, selectPlayTarget(movie, emptyList(), nextUp = video("e2", VideoKind.EPISODE)))
+    }
 }


### PR DESCRIPTION
Closes the four tier-1 gaps in the video feature, picked from a gap audit of steps 1 (#148) and 2 (#149). Subtitles and audio-track selection were deliberately deferred.

## Continue watching rail

Home gains a "Continue watching" rail between "On your device" and "Movies & shows", built to the `Continue Card` component in `happypath.pen`: a 16:9 still with a 3dp progress bar on its bottom edge, the title, and a `S2 E4 · 23 min left` meta line with an offline check when a local copy exists.

Tapping a card resumes straight in the player, skipping the detail screen. The rail merges the server's `getResumeItems` with the local progress table, so **it still works with no network**.

## Next episode

`selectPlayTarget` now prefers the server's Next Up episode. Jellyfin zeroes a watched episode's position, so the old "first in-progress episode" scan sent a user who had just finished E1 back to E1 instead of E2. The local scan remains as the offline fallback.

The player also auto-advances when an episode ends, and offers a skip pill. Both are keyed on **season position** rather than Next Up — autoplay should roll into the literal next episode, which is a different question from "where do I resume this series".

The pill is a bespoke control rather than `PlayerView`'s next button: the player holds a single `MediaItem` at a time (each episode negotiates its own stream), so the built-in one would render permanently disabled.

## Offline resume

Watch positions were server-only, so a downloaded title — precisely the one watched offline — reported into the void and restarted from zero on the next launch.

Positions now also land in a new `video_progress` table (migration 2 → 3, schema exported). On resume, whichever side was **written more recently** wins. Comparing by recency rather than taking the larger position matters: a deliberate rewind on one device would otherwise be undone by the other side's stale, larger value.

## PlaybackInfo negotiation

Transcode URLs assumed the media source id was the item id unhyphenated, which holds for plain single-file items but breaks for multi-version and `.strm`-backed ones. Both the HLS stream URL and the download URL now negotiate it via `mediaInfoApi.getPostedPlaybackInfo`, falling back to the old guess so a negotiation failure degrades rather than blocks playback.

## API shape change

`videoSourceResolver`, `videoStreamCandidates`, and `videoDownloadUrl` are now `suspend` — negotiating the media source id is a network call.

## Verification

Device-verified on a Pixel 8 against a live Jellyfin server:

| Check | Result |
|---|---|
| v2 → v3 migration on an existing DB | clean, no crash |
| Rail rendering | real stills, correct progress bars and time-left |
| Resume — movie | *Before Midnight* opened deep into the film, matching "22 min left" |
| Resume — episode | S3 E2 resumed mid-episode |
| Skip pill | showed S3 E3 while playing S3 E2; tapping advanced to E3, pill became S3 E4 |
| Stream negotiation | h264 decoder + audio focus confirmed in logcat |

Gates: `compileDebugKotlin`, `detekt`, and `assembleDebug` all clean. Unit tests **57 passing**, up from 42 — new coverage for `resolveResumePosition` (including the rewind case), `isFinished`, `mergeContinueWatching`, `formatTimeLeft`, and the Next Up branches of `selectPlayTarget`.

## Still open after this

Subtitles remain the largest gap, followed by audio-track selection, PiP, orientation lock, video search (`repository.search` is AUDIO-only), season grouping and paging, and the architectural point that video runs a raw ExoPlayer in a ViewModel — no MediaSession, hence no lock-screen/Bluetooth controls, background playback, or Android Auto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
