### PR TITLE
Add SessionStart hook to provision Android SDK on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Provisions the Android SDK for Claude Code on the web sessions. The cloud
+# sandbox ships a JDK but no Android toolchain, so without this every Gradle
+# invocation dies at "Plugin [id: 'com.android.application'] was not found".
+# Safe to re-run: sdkmanager skips packages that are already installed.
+set -euo pipefail
+
+# Local machines and dev containers already have their own SDK.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+ANDROID_HOME="${ANDROID_HOME:-$HOME/android-sdk}"
+CMDLINE_TOOLS_VERSION="13114758"
+
+# Keep these in sync with app/build.gradle.kts: compileSdk release(37) needs
+# platforms;android-37.0, and buildToolsVersion defaults to the AGP pin.
+SDK_PACKAGES=(
+  "platform-tools"
+  "platforms;android-37.0"
+  "platforms;android-36"
+  "build-tools;36.0.0"
+)
+
+if [ ! -x "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" ]; then
+  echo "Installing Android cmdline-tools into $ANDROID_HOME"
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  curl -fsSL --retry 3 --retry-delay 2 \
+    -o "$tmp/cmdline-tools.zip" \
+    "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+  unzip -q "$tmp/cmdline-tools.zip" -d "$tmp"
+  mkdir -p "$ANDROID_HOME/cmdline-tools"
+  rm -rf "$ANDROID_HOME/cmdline-tools/latest"
+  mv "$tmp/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest"
+fi
+
+export ANDROID_HOME
+export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH"
+
+# AGP also auto-downloads missing SDK components, which needs the licenses too.
+yes | sdkmanager --licenses > /dev/null 2>&1 || true
+sdkmanager "${SDK_PACKAGES[@]}" > /dev/null
+
+# Gradle finds the SDK via local.properties (gitignored) or ANDROID_HOME.
+printf 'sdk.dir=%s\n' "$ANDROID_HOME" > "$CLAUDE_PROJECT_DIR/local.properties"
+
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    printf 'export ANDROID_HOME=%s\n' "$ANDROID_HOME"
+    printf 'export ANDROID_SDK_ROOT=%s\n' "$ANDROID_HOME"
+    printf 'export PATH="%s/cmdline-tools/latest/bin:%s/platform-tools:$PATH"\n' \
+      "$ANDROID_HOME" "$ANDROID_HOME"
+  } >> "$CLAUDE_ENV_FILE"
+fi
+
+echo "Android SDK ready at $ANDROID_HOME"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,10 @@ local.properties
 
 .kotlin
 
-.claude
+# Local Claude Code state stays out of the repo, except the shared
+# session-start hook that provisions the Android SDK for Claude Code on the web.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/hooks/*
+!.claude/hooks/session-start.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Mixtape Haven is an Android application built with Kotlin and Jetpack Compose. T
 **Package:** `pe.net.libre.mixtapehaven`
 **Min SDK:** 33
 **Target SDK:** 36
-**Compile SDK:** 36
+**Compile SDK:** 37
 **Java Version:** 11
 
 ## Build Commands
@@ -40,8 +40,8 @@ Mixtape Haven is an Android application built with Kotlin and Jetpack Compose. T
 
 ### Run specific test
 ```bash
-# Unit test
-./gradlew test --tests pe.net.libre.mixtapehaven.ExampleUnitTest
+# Unit test — filter on the variant task; the aggregate `test` task rejects --tests
+./gradlew testDebugUnitTest --tests pe.net.libre.mixtapehaven.ExampleUnitTest
 
 # Instrumented test
 ./gradlew connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=pe.net.libre.mixtapehaven.ExampleInstrumentedTest
@@ -68,7 +68,7 @@ Mixtape Haven is an Android application built with Kotlin and Jetpack Compose. T
 
 ### Dependencies
 Dependencies are managed via Gradle version catalog in `gradle/libs.versions.toml`. Key dependencies:
-- Jetpack Compose BOM (2024.09.00)
+- Jetpack Compose BOM (2026.06.01)
 - Material 3
 - Lifecycle Runtime KTX
 - Activity Compose


### PR DESCRIPTION
Claude Code on the web runs in a cloud sandbox that ships a JDK but no
Android toolchain, so every Gradle invocation failed at plugin resolution
("Plugin [id: 'com.android.application'] was not found"). The dev container's
post-create.sh only covers local containers.

The hook installs cmdline-tools, accepts licenses, and pulls the platform and
build-tools this project targets, then points Gradle at the SDK via
local.properties and CLAUDE_ENV_FILE. It no-ops outside remote sessions so
local setups keep their own SDK, and re-running it is a no-op once installed.

.claude/ stays ignored apart from the two files needed to share the hook.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WijdWCHQ29LbGTRQKCgsvm