### PR TITLE
Add buffering indicator to video player

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -121,7 +123,11 @@ fun VideoPlayerScreen(
 private fun BufferingIndicator(modifier: Modifier = Modifier) {
     CircularProgressIndicator(
         color = Accent,
-        modifier = modifier.size(48.dp),
+        // Without this the load is silent to TalkBack — the black frame with no announcement is
+        // the exact state this indicator exists to explain.
+        modifier = modifier
+            .size(48.dp)
+            .semantics { contentDescription = "Loading video" },
     )
 }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -35,6 +36,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.PlayerView
 import pe.net.libre.mixtapehaven.di.appViewModel
+import pe.net.libre.mixtapehaven.ui.theme.Accent
 import pe.net.libre.mixtapehaven.ui.theme.TextPrimary
 
 /** Full-screen video playback surface using media3's [PlayerView] for transport controls. */
@@ -59,6 +61,7 @@ fun VideoPlayerScreen(
     }
     val error by viewModel.error.collectAsState()
     val upNext by viewModel.upNext.collectAsState()
+    val buffering by viewModel.buffering.collectAsState()
 
     // No background video service exists, so pause when the screen stops (Home button, lock);
     // otherwise audio would keep playing invisibly and the progress loop would churn the radio.
@@ -84,6 +87,15 @@ fun VideoPlayerScreen(
             onRelease = { it.player = null },
             modifier = Modifier.fillMaxSize(),
         )
+
+        // Suppressed once an error is up: the message explains the black frame better than a
+        // spinner that would never resolve.
+        if (buffering && error == null) {
+            CircularProgressIndicator(
+                color = Accent,
+                modifier = Modifier.align(Alignment.Center).size(48.dp),
+            )
+        }
 
         error?.let { message ->
             Text(

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
@@ -91,10 +91,7 @@ fun VideoPlayerScreen(
         // Suppressed once an error is up: the message explains the black frame better than a
         // spinner that would never resolve.
         if (buffering && error == null) {
-            CircularProgressIndicator(
-                color = Accent,
-                modifier = Modifier.align(Alignment.Center).size(48.dp),
-            )
+            BufferingIndicator(modifier = Modifier.align(Alignment.Center))
         }
 
         error?.let { message ->
@@ -117,6 +114,15 @@ fun VideoPlayerScreen(
             )
         }
     }
+}
+
+/** Spinner shown over the black frame while a stream is being resolved or buffered. */
+@Composable
+private fun BufferingIndicator(modifier: Modifier = Modifier) {
+    CircularProgressIndicator(
+        color = Accent,
+        modifier = modifier.size(48.dp),
+    )
 }
 
 /** Circular back affordance over the video surface, which has no system chrome of its own. */

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
@@ -59,6 +59,14 @@ class VideoPlayerViewModel(
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
 
+    /**
+     * True whenever the surface has nothing to show: resolving a stream, filling the initial buffer,
+     * rebuffering mid-playback, or re-preparing on the transcode fallback. Starts true because [init]
+     * launches straight into [startItem].
+     */
+    private val _buffering = MutableStateFlow(true)
+    val buffering: StateFlow<Boolean> = _buffering.asStateFlow()
+
     /** The item currently on screen; changes when autoplay advances to the next episode. */
     private val _nowPlaying = MutableStateFlow<VideoItem?>(null)
     val nowPlaying: StateFlow<VideoItem?> = _nowPlaying.asStateFlow()
@@ -76,8 +84,16 @@ class VideoPlayerViewModel(
     private val listener = object : Player.Listener {
         override fun onPlaybackStateChanged(playbackState: Int) {
             when (playbackState) {
-                Player.STATE_READY -> reachedReady = true
-                Player.STATE_ENDED -> onPlaybackEnded()
+                Player.STATE_BUFFERING -> _buffering.value = true
+                Player.STATE_READY -> {
+                    reachedReady = true
+                    _buffering.value = false
+                }
+                Player.STATE_ENDED -> {
+                    _buffering.value = false
+                    onPlaybackEnded()
+                }
+                // STATE_IDLE follows an error or a release; the error path below owns the flag there.
                 else -> Unit
             }
         }
@@ -88,8 +104,11 @@ class VideoPlayerViewModel(
             val positionMs = player.currentPosition.coerceAtLeast(0)
             if (candidateIndex + 1 < candidates.size) {
                 candidateIndex++
+                // Keep the indicator up: the swap to the transcode is another wait, not a resume.
+                _buffering.value = true
                 prepareCurrentCandidate(startMs = positionMs)
             } else {
+                _buffering.value = false
                 _error.value = error.message ?: "Playback failed"
             }
         }
@@ -111,9 +130,13 @@ class VideoPlayerViewModel(
         // Cleared up front so a hop that fails below cannot leave the pill pointing at the
         // previous episode's successor, and so it never shows a stale value while loadUpNext runs.
         _upNext.value = null
+        // Resolving the item and its sources are network hops with the player still idle, so the
+        // flag is raised here rather than waiting for STATE_BUFFERING.
+        _buffering.value = true
         val resolved = progressStore.resolvePlayback(id)
         val item = resolved.item
         if (item == null) {
+            _buffering.value = false
             _error.value = "Could not load this title"
             return
         }
@@ -122,6 +145,7 @@ class VideoPlayerViewModel(
         candidateIndex = 0
         reachedReady = false
         if (candidates.isEmpty()) {
+            _buffering.value = false
             _error.value = "No playable source for this title"
             return
         }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -125,14 +126,34 @@ class VideoPlayerViewModel(
         }
     }
 
-    /** Load [id], resume it, and begin playing. Used for the initial item and each autoplay hop. */
+    /**
+     * Load [id], resume it, and begin playing. Used for the initial item and each autoplay hop.
+     *
+     * Owns the buffering flag for the whole attempt so the indicator cannot outlive it: [prepareItem]
+     * clears it on the paths that end in an error, and a throw is caught here. Neither seam it calls
+     * is fully guarded — [resolveSources] is injected, and the Room read inside `resolvePlayback` is
+     * unguarded — and a spinner turning forever reads worse than the black frame it replaced.
+     */
     private suspend fun startItem(id: String) {
         // Cleared up front so a hop that fails below cannot leave the pill pointing at the
         // previous episode's successor, and so it never shows a stale value while loadUpNext runs.
         _upNext.value = null
+        // The previous item's error goes with it: the screen hides the indicator whenever an error
+        // is up, so a stale one would leave the next hop looking frozen for the whole resolve
+        // window rather than showing that work is under way.
+        _error.value = null
         // Resolving the item and its sources are network hops with the player still idle, so the
         // flag is raised here rather than waiting for STATE_BUFFERING.
         _buffering.value = true
+        val failure = runCatching { prepareItem(id) }.exceptionOrNull() ?: return
+        // Cancellation is the scope shutting down, not a load failure; let it unwind.
+        if (failure is CancellationException) throw failure
+        _buffering.value = false
+        _error.value = "Could not load this title"
+    }
+
+    /** The load proper; [startItem] wraps it so every exit clears the buffering flag. */
+    private suspend fun prepareItem(id: String) {
         val resolved = progressStore.resolvePlayback(id)
         val item = resolved.item
         if (item == null) {
@@ -149,7 +170,6 @@ class VideoPlayerViewModel(
             _error.value = "No playable source for this title"
             return
         }
-        _error.value = null
         prepareCurrentCandidate(startMs = resolved.positionMs)
         progressStore.record(item, resolved.positionMs, player.duration.durationOrZero(), VideoPlaybackEvent.STARTED)
         _upNext.value = loadUpNext(item)


### PR DESCRIPTION
## Summary
Adds a buffering state indicator to the video player screen that displays a loading spinner while the player is resolving streams, buffering content, or preparing fallback transcodes.

## Key Changes
- **VideoPlayerViewModel:** Introduced a new `buffering` StateFlow that tracks when the player surface has nothing to show
  - Set to `true` when entering `STATE_BUFFERING` or during network operations (stream resolution, source loading)
  - Set to `false` when reaching `STATE_READY`, `STATE_ENDED`, or when errors occur
  - Properly managed during transcode fallback attempts to indicate the swap is another wait, not a resume
  
- **VideoPlayerScreen:** Added a `CircularProgressIndicator` that displays centered on the player when buffering
  - Uses the app's `Accent` color for visual consistency
  - Suppressed when an error message is displayed (error message better explains the black frame)
  - 48dp size for appropriate visibility

## Implementation Details
The buffering flag is raised proactively during network operations (item resolution, source loading) rather than waiting for the player's `STATE_BUFFERING` event, ensuring the indicator appears immediately during these initial setup phases. The flag is properly cleared in all error paths to prevent the spinner from displaying indefinitely.

https://claude.ai/code/session_01CZ4vHvauXk5hkNvWHoxkYW