### PR TITLE
fix: open the app from the now playing notification

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,12 @@ android {
     buildFeatures {
         compose = true
     }
+    testOptions {
+        unitTests {
+            // Robolectric needs the merged manifest and resources on the unit-test classpath.
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -89,6 +95,8 @@ dependencies {
     detektPlugins(libs.detekt.compose)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.room.testing)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.Mixtape">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/pe/net/libre/mixtapehaven/MainActivity.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/MainActivity.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.ui.navigation.AppStateViewModel
 import pe.net.libre.mixtapehaven.ui.navigation.MixtapeNavHost
+import pe.net.libre.mixtapehaven.ui.navigation.NoPendingRoute
 import pe.net.libre.mixtapehaven.ui.navigation.Routes
 import pe.net.libre.mixtapehaven.ui.theme.Bg
 import pe.net.libre.mixtapehaven.ui.theme.MixtapeTheme
@@ -25,14 +26,18 @@ class MainActivity : ComponentActivity() {
 
     /** Route requested by the intent that opened (or re-opened) the app; null once consumed. */
     private val _pendingRoute = MutableStateFlow<String?>(null)
+    private val pendingRoute: StateFlow<String?> = _pendingRoute.asStateFlow()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        readPendingRoute(intent)
+        // Only on a fresh launch. A non-null savedInstanceState means the activity is being
+        // recreated (rotation, or Recents after a process kill), and the launch intent the system
+        // replays still carries the extra — honouring it would yank the user back to Now Playing.
+        if (savedInstanceState == null) readPendingRoute(intent)
         setContent {
             MixtapeApp(
-                pendingRoute = _pendingRoute.asStateFlow(),
+                pendingRoute = pendingRoute,
                 onRouteConsumed = { _pendingRoute.value = null },
             )
         }
@@ -50,6 +55,9 @@ class MainActivity : ComponentActivity() {
 
     private fun readPendingRoute(intent: Intent) {
         if (intent.getBooleanExtra(EXTRA_OPEN_NOW_PLAYING, false)) {
+            // Consume it: [setIntent] retains this intent, so leaving the extra in place would
+            // replay the request the next time the activity is recreated from it.
+            intent.removeExtra(EXTRA_OPEN_NOW_PLAYING)
             _pendingRoute.value = Routes.NOW_PLAYING
         }
     }
@@ -62,7 +70,7 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun MixtapeApp(
-    pendingRoute: StateFlow<String?> = MutableStateFlow(null),
+    pendingRoute: StateFlow<String?> = NoPendingRoute,
     onRouteConsumed: () -> Unit = {},
 ) {
     val appState = appViewModel { AppStateViewModel(it.repository) }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/MainActivity.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/MainActivity.kt
@@ -54,18 +54,24 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun readPendingRoute(intent: Intent) {
-        if (intent.getBooleanExtra(EXTRA_OPEN_NOW_PLAYING, false)) {
-            // Consume it: [setIntent] retains this intent, so leaving the extra in place would
-            // replay the request the next time the activity is recreated from it.
-            intent.removeExtra(EXTRA_OPEN_NOW_PLAYING)
-            _pendingRoute.value = Routes.NOW_PLAYING
-        }
+        consumeNowPlayingRequest(intent)?.let { _pendingRoute.value = it }
     }
 
     companion object {
         /** Set by the playback notification's content intent to open Now Playing on arrival. */
         const val EXTRA_OPEN_NOW_PLAYING = "pe.net.libre.mixtapehaven.OPEN_NOW_PLAYING"
     }
+}
+
+/**
+ * The route [intent] asks to open, or null if it carries no request. Reading is destructive: the
+ * extra is removed, because [MainActivity.setIntent] retains the intent and the system replays it
+ * whenever the activity is recreated from it — a second read must not re-navigate the user.
+ */
+internal fun consumeNowPlayingRequest(intent: Intent): String? {
+    if (!intent.getBooleanExtra(MainActivity.EXTRA_OPEN_NOW_PLAYING, false)) return null
+    intent.removeExtra(MainActivity.EXTRA_OPEN_NOW_PLAYING)
+    return Routes.NOW_PLAYING
 }
 
 @Composable

--- a/app/src/main/java/pe/net/libre/mixtapehaven/MainActivity.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/MainActivity.kt
@@ -1,5 +1,6 @@
 package pe.net.libre.mixtapehaven
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,28 +11,72 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.ui.navigation.AppStateViewModel
 import pe.net.libre.mixtapehaven.ui.navigation.MixtapeNavHost
+import pe.net.libre.mixtapehaven.ui.navigation.Routes
 import pe.net.libre.mixtapehaven.ui.theme.Bg
 import pe.net.libre.mixtapehaven.ui.theme.MixtapeTheme
 
 class MainActivity : ComponentActivity() {
+
+    /** Route requested by the intent that opened (or re-opened) the app; null once consumed. */
+    private val _pendingRoute = MutableStateFlow<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContent { MixtapeApp() }
+        readPendingRoute(intent)
+        setContent {
+            MixtapeApp(
+                pendingRoute = _pendingRoute.asStateFlow(),
+                onRouteConsumed = { _pendingRoute.value = null },
+            )
+        }
+    }
+
+    /**
+     * The activity is `singleTask`, so tapping the media notification while the app is already
+     * running re-delivers here instead of going through [onCreate].
+     */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        readPendingRoute(intent)
+    }
+
+    private fun readPendingRoute(intent: Intent) {
+        if (intent.getBooleanExtra(EXTRA_OPEN_NOW_PLAYING, false)) {
+            _pendingRoute.value = Routes.NOW_PLAYING
+        }
+    }
+
+    companion object {
+        /** Set by the playback notification's content intent to open Now Playing on arrival. */
+        const val EXTRA_OPEN_NOW_PLAYING = "pe.net.libre.mixtapehaven.OPEN_NOW_PLAYING"
     }
 }
 
 @Composable
-fun MixtapeApp() {
+fun MixtapeApp(
+    pendingRoute: StateFlow<String?> = MutableStateFlow(null),
+    onRouteConsumed: () -> Unit = {},
+) {
     val appState = appViewModel { AppStateViewModel(it.repository) }
     val startDestination by appState.startDestination.collectAsState()
     MixtapeTheme {
         Surface(modifier = Modifier.fillMaxSize(), color = Bg) {
             // Keep the splash background until the session has been restored.
-            startDestination?.let { MixtapeNavHost(startDestination = it) }
+            startDestination?.let {
+                MixtapeNavHost(
+                    startDestination = it,
+                    pendingRoute = pendingRoute,
+                    onRouteConsumed = onRouteConsumed,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlaybackService.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlaybackService.kt
@@ -1,5 +1,6 @@
 package pe.net.libre.mixtapehaven.data.playback
 
+import android.app.PendingIntent
 import android.content.Intent
 import androidx.annotation.OptIn
 import androidx.media3.common.C
@@ -11,6 +12,7 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import okhttp3.OkHttpClient
+import pe.net.libre.mixtapehaven.MainActivity
 
 /** Foreground [MediaSessionService] hosting the single ExoPlayer instance for the app. */
 @OptIn(UnstableApi::class)
@@ -30,7 +32,29 @@ class PlaybackService : MediaSessionService() {
             // Hold CPU + WiFi awake only while playing, so streaming survives screen-off/doze.
             .setWakeMode(C.WAKE_MODE_NETWORK)
             .build()
-        mediaSession = MediaSession.Builder(this, player).build()
+        mediaSession = MediaSession.Builder(this, player)
+            .setSessionActivity(nowPlayingIntent())
+            .build()
+    }
+
+    /**
+     * Where a tap on the media notification — or on the system's Now Playing tile — lands.
+     * Without a session activity media3 builds the notification with no content intent, so
+     * tapping it does nothing at all. [MainActivity] is `singleTask`, so this brings the
+     * existing task forward and is delivered to `onNewIntent` rather than restarting the app.
+     */
+    private fun nowPlayingIntent(): PendingIntent {
+        val intent = Intent(this, MainActivity::class.java)
+            .setAction(Intent.ACTION_MAIN)
+            .addCategory(Intent.CATEGORY_LAUNCHER)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            .putExtra(MainActivity.EXTRA_OPEN_NOW_PLAYING, true)
+        return PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlaybackService.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlaybackService.kt
@@ -1,6 +1,7 @@
 package pe.net.libre.mixtapehaven.data.playback
 
 import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
 import androidx.annotation.OptIn
 import androidx.media3.common.C
@@ -33,28 +34,8 @@ class PlaybackService : MediaSessionService() {
             .setWakeMode(C.WAKE_MODE_NETWORK)
             .build()
         mediaSession = MediaSession.Builder(this, player)
-            .setSessionActivity(nowPlayingIntent())
+            .setSessionActivity(nowPlayingSessionActivity(this))
             .build()
-    }
-
-    /**
-     * Where a tap on the media notification — or on the system's Now Playing tile — lands.
-     * Without a session activity media3 builds the notification with no content intent, so
-     * tapping it does nothing at all. [MainActivity] is `singleTask`, so this brings the
-     * existing task forward and is delivered to `onNewIntent` rather than restarting the app.
-     */
-    private fun nowPlayingIntent(): PendingIntent {
-        val intent = Intent(this, MainActivity::class.java)
-            .setAction(Intent.ACTION_MAIN)
-            .addCategory(Intent.CATEGORY_LAUNCHER)
-            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            .putExtra(MainActivity.EXTRA_OPEN_NOW_PLAYING, true)
-        return PendingIntent.getActivity(
-            this,
-            0,
-            intent,
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
-        )
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession
@@ -74,4 +55,24 @@ class PlaybackService : MediaSessionService() {
         mediaSession = null
         super.onDestroy()
     }
+}
+
+/**
+ * Where a tap on the media notification — or on the system's Now Playing tile — lands. Without a
+ * session activity media3 builds the notification with no content intent, so tapping it does
+ * nothing at all. [MainActivity] is `singleTask`, so this brings the existing task forward and is
+ * delivered to `onNewIntent` rather than restarting the app.
+ */
+internal fun nowPlayingSessionActivity(context: Context): PendingIntent {
+    val intent = Intent(context, MainActivity::class.java)
+        .setAction(Intent.ACTION_MAIN)
+        .addCategory(Intent.CATEGORY_LAUNCHER)
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        .putExtra(MainActivity.EXTRA_OPEN_NOW_PLAYING, true)
+    return PendingIntent.getActivity(
+        context,
+        0,
+        intent,
+        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+    )
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeDestinations.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeDestinations.kt
@@ -14,3 +14,13 @@ object Routes {
     fun videoDetail(itemId: String) = "video_detail/$itemId"
     fun videoPlayer(itemId: String) = "video_player/$itemId"
 }
+
+/**
+ * The route to navigate to for an externally [requested] one (e.g. a tap on the playback
+ * notification), or null to ignore it. Requests are dropped while signed out — Now Playing behind
+ * the login wall has nothing to show — and when the user is already on the target route.
+ */
+internal fun resolveDeepLink(requested: String, currentRoute: String): String? {
+    if (currentRoute == Routes.LOGIN) return null
+    return requested.takeIf { it != currentRoute }
+}

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeDestinations.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeDestinations.kt
@@ -1,5 +1,15 @@
 package pe.net.libre.mixtapehaven.ui.navigation
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * A route request that never arrives — the default where no deep link is possible (previews,
+ * tests). A shared instance, so composables defaulting to it do not allocate a new flow per
+ * recomposition and reset the state collected from it.
+ */
+val NoPendingRoute: StateFlow<String?> = MutableStateFlow(null)
+
 object Routes {
     const val LOGIN = "login"
     const val HOME = "home"

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
@@ -1,6 +1,9 @@
 package pe.net.libre.mixtapehaven.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraphBuilder
@@ -9,6 +12,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import pe.net.libre.mixtapehaven.di.AppContainer
 import pe.net.libre.mixtapehaven.di.appContainer
@@ -24,10 +29,26 @@ import pe.net.libre.mixtapehaven.ui.screens.video.VideoLibraryScreen
 import pe.net.libre.mixtapehaven.ui.screens.video.VideoPlayerScreen
 
 @Composable
-fun MixtapeNavHost(startDestination: String, modifier: Modifier = Modifier) {
+fun MixtapeNavHost(
+    startDestination: String,
+    modifier: Modifier = Modifier,
+    pendingRoute: StateFlow<String?> = MutableStateFlow(null),
+    onRouteConsumed: () -> Unit = {},
+) {
     val navController = rememberNavController()
     val container = appContainer()
     val scope = rememberCoroutineScope()
+
+    val requestedRoute by pendingRoute.collectAsState()
+    LaunchedEffect(requestedRoute) {
+        val request = requestedRoute ?: return@LaunchedEffect
+        // currentDestination is null until the graph is attached, so fall back to the start route.
+        val current = navController.currentDestination?.route ?: startDestination
+        resolveDeepLink(request, current)?.let { route ->
+            navController.navigate(route) { launchSingleTop = true }
+        }
+        onRouteConsumed()
+    }
 
     NavHost(
         navController = navController,

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/navigation/MixtapeNavHost.kt
@@ -12,7 +12,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import pe.net.libre.mixtapehaven.di.AppContainer
@@ -32,7 +31,7 @@ import pe.net.libre.mixtapehaven.ui.screens.video.VideoPlayerScreen
 fun MixtapeNavHost(
     startDestination: String,
     modifier: Modifier = Modifier,
-    pendingRoute: StateFlow<String?> = MutableStateFlow(null),
+    pendingRoute: StateFlow<String?> = NoPendingRoute,
     onRouteConsumed: () -> Unit = {},
 ) {
     val navController = rememberNavController()

--- a/app/src/test/java/pe/net/libre/mixtapehaven/NowPlayingRequestTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/NowPlayingRequestTest.kt
@@ -1,0 +1,54 @@
+package pe.net.libre.mixtapehaven
+
+import android.app.Application
+import android.content.Intent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import pe.net.libre.mixtapehaven.ui.navigation.Routes
+
+/**
+ * The deep-link half of "tapping the media notification opens the app". Runs against a plain
+ * [Application] so the real one's dependency container (Room, DataStore, Jellyfin SDK) is not
+ * built for what is only intent parsing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class NowPlayingRequestTest {
+
+    private fun notificationIntent() =
+        Intent().putExtra(MainActivity.EXTRA_OPEN_NOW_PLAYING, true)
+
+    @Test
+    fun `notification intent requests now playing`() {
+        assertEquals(Routes.NOW_PLAYING, consumeNowPlayingRequest(notificationIntent()))
+    }
+
+    @Test
+    fun `a plain launch intent requests nothing`() {
+        assertNull(consumeNowPlayingRequest(Intent()))
+    }
+
+    @Test
+    fun `reading strips the extra from the intent`() {
+        val intent = notificationIntent()
+        consumeNowPlayingRequest(intent)
+        assertFalse(intent.hasExtra(MainActivity.EXTRA_OPEN_NOW_PLAYING))
+    }
+
+    /**
+     * The regression behind the review finding: the activity retains this intent, and the system
+     * replays it on every recreation (rotation, Recents after a process kill). A second read must
+     * not navigate, or the user is yanked back to Now Playing from wherever they were.
+     */
+    @Test
+    fun `a replayed intent does not request again`() {
+        val intent = notificationIntent()
+        assertEquals(Routes.NOW_PLAYING, consumeNowPlayingRequest(intent))
+        assertNull(consumeNowPlayingRequest(intent))
+    }
+}

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/SessionActivityTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/SessionActivityTest.kt
@@ -1,0 +1,48 @@
+package pe.net.libre.mixtapehaven.data.playback
+
+import android.app.Application
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import pe.net.libre.mixtapehaven.MainActivity
+
+/**
+ * The other half of the notification tap: what media3 is handed as the session activity. Covers
+ * the original bug — a session with no content intent, so tapping the notification did nothing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class SessionActivityTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    private fun sessionIntent(): Intent = shadowOf(nowPlayingSessionActivity(context)).savedIntent
+
+    @Test
+    fun `targets the launcher activity`() {
+        assertEquals(MainActivity::class.java.name, sessionIntent().component?.className)
+    }
+
+    @Test
+    fun `asks for now playing`() {
+        assertTrue(sessionIntent().getBooleanExtra(MainActivity.EXTRA_OPEN_NOW_PLAYING, false))
+    }
+
+    /** Launching from a service context requires its own task. */
+    @Test
+    fun `starts a new task`() {
+        assertTrue(sessionIntent().flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    /** Required on API 31+, and the intent carries no data the receiver should be able to alter. */
+    @Test
+    fun `is immutable`() {
+        assertTrue(shadowOf(nowPlayingSessionActivity(context)).isImmutable)
+    }
+}

--- a/app/src/test/java/pe/net/libre/mixtapehaven/ui/navigation/DeepLinkTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/ui/navigation/DeepLinkTest.kt
@@ -1,0 +1,28 @@
+package pe.net.libre.mixtapehaven.ui.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DeepLinkTest {
+
+    @Test
+    fun `opens now playing from home`() {
+        assertEquals(Routes.NOW_PLAYING, resolveDeepLink(Routes.NOW_PLAYING, Routes.HOME))
+    }
+
+    @Test
+    fun `opens now playing from a nested screen`() {
+        assertEquals(Routes.NOW_PLAYING, resolveDeepLink(Routes.NOW_PLAYING, Routes.SETTINGS))
+    }
+
+    @Test
+    fun `ignores the request while signed out`() {
+        assertNull(resolveDeepLink(Routes.NOW_PLAYING, Routes.LOGIN))
+    }
+
+    @Test
+    fun `ignores the request when already on the target`() {
+        assertNull(resolveDeepLink(Routes.NOW_PLAYING, Routes.NOW_PLAYING))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ detekt = "1.23.8"
 detektCompose = "0.6.3"
 jellyfin = "1.8.12"
 slf4j = "2.0.18"
+robolectric = "4.16"
+androidxTestCore = "1.7.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -67,6 +69,8 @@ androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx"
 detekt-compose = { module = "io.nlopez.compose.rules:detekt", version.ref = "detektCompose" }
 jellyfin-core = { group = "org.jellyfin.sdk", name = "jellyfin-core", version.ref = "jellyfin" }
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
MediaSession was built without a session activity, so media3 generated the
playback notification with no content intent — tapping the notification or the
system Now Playing tile did nothing.

Set a session activity that launches MainActivity with an extra requesting the
Now Playing route, and make MainActivity singleTask so a tap while the app is
already running brings the existing task forward (delivered via onNewIntent)
instead of restarting it. The requested route is dropped while signed out or
when already on Now Playing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ks2BLHxFTPUUJRyjKwLrxy