### PR TITLE
fix: stop battery drain from held wake locks and ungated polling

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlaybackService.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlaybackService.kt
@@ -3,6 +3,8 @@ package pe.net.libre.mixtapehaven.data.playback
 import android.content.Intent
 import androidx.annotation.OptIn
 import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
@@ -27,9 +29,17 @@ class PlaybackService : MediaSessionService() {
         val player = ExoPlayer.Builder(this)
             .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
             .setHandleAudioBecomingNoisy(true)
-            // Hold CPU + WiFi awake only while playing, so streaming survives screen-off/doze.
-            .setWakeMode(C.WAKE_MODE_NETWORK)
+            // Hold the CPU awake only while playing, so playback survives screen-off/doze. The
+            // Wi-Fi half is added per item below, and only when the item is actually streamed.
+            .setWakeMode(C.WAKE_MODE_LOCAL)
             .build()
+        player.addListener(
+            object : Player.Listener {
+                override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                    player.setWakeMode(wakeModeForUri(mediaItem?.localConfiguration?.uri?.toString()))
+                }
+            },
+        )
         mediaSession = MediaSession.Builder(this, player).build()
     }
 
@@ -51,3 +61,22 @@ class PlaybackService : MediaSessionService() {
         super.onDestroy()
     }
 }
+
+/**
+ * The wake mode an item needs, from the URI its bytes come from.
+ *
+ * [C.WAKE_MODE_NETWORK] adds a WifiLock on top of the CPU lock, which holds the Wi-Fi radio out of
+ * power-save for as long as the item plays. A stream needs that; a downloaded file does not, and
+ * offline playback is precisely the long screen-off case where the wasted lock costs the most.
+ * Anything that is not plainly http(s) — `file://`, `content://`, an unset URI — is treated as
+ * local, so an unrecognised scheme errs towards the cheaper lock rather than the wasteful one.
+ *
+ * Pure (media3 constants only, no player or Android framework types) so the decision is
+ * unit-coverable.
+ */
+internal fun wakeModeForUri(uri: String?): Int =
+    if (uri != null && (uri.startsWith("http://", true) || uri.startsWith("https://", true))) {
+        C.WAKE_MODE_NETWORK
+    } else {
+        C.WAKE_MODE_LOCAL
+    }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -108,6 +108,30 @@ class PlayerController(
         }
     }
 
+    /**
+     * Session liveness, kept separate from the progress poll.
+     *
+     * A session that dies mid-playback sends no [Player.Listener] callback, so this used to be
+     * noticed only by the poll loop finding a null controller. That detection cannot live in the
+     * loop any more: the loop is gated on a Now Playing subscriber, which is absent in exactly the
+     * case the service is most likely to be reclaimed — backgrounded and under memory pressure.
+     * Left stuck, [isPlaying] would keep Home's mini-player showing Pause for a player that no
+     * longer exists, and tapping it would do nothing.
+     *
+     * A listener rather than a slow poll: this is an event the session already reports, and a
+     * second timer ticking through backgrounded playback is the cost this change set exists to
+     * remove.
+     */
+    private val controllerListener = object : MediaController.Listener {
+        override fun onDisconnected(controller: MediaController) {
+            // Ignore a stale controller already replaced by reconnect().
+            if (this@PlayerController.controller !== controller) return
+            controller.release()
+            this@PlayerController.controller = null
+            _isPlaying.value = false
+        }
+    }
+
     init {
         // Poll position/duration only while something is playing *and* a screen is displaying it.
         //
@@ -123,13 +147,9 @@ class PlayerController(
                 .collectLatest { shouldPoll ->
                     if (!shouldPoll) return@collectLatest
                     while (currentCoroutineContext().isActive) {
-                        val c = activeController()
-                        if (c == null) {
-                            // Controller lost mid-playback (service killed): stop polling and reset
-                            // the flag, else its conflated true would keep the loop from restarting.
-                            _isPlaying.value = false
-                            break
-                        }
+                        // Backstop only; [controllerListener] owns liveness. Still worth breaking
+                        // on, so a loop that outlives its controller stops rather than spinning.
+                        val c = activeController() ?: break
                         _durationMs.value = c.duration.coerceAtLeast(0)
                         _positionMs.value = c.currentPosition.coerceAtLeast(0)
                         delay(PROGRESS_INTERVAL_MS)
@@ -267,7 +287,9 @@ class PlayerController(
         if (connecting) return
         connecting = true
         val token = SessionToken(appContext, ComponentName(appContext, PlaybackService::class.java))
-        val future = MediaController.Builder(appContext, token).buildAsync()
+        val future = MediaController.Builder(appContext, token)
+            .setListener(controllerListener)
+            .buildAsync()
         future.addListener(
             {
                 connecting = false

--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/playback/PlayerController.kt
@@ -17,10 +17,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import pe.net.libre.mixtapehaven.data.diagnostics.DiagnosticsLog
@@ -107,26 +109,45 @@ class PlayerController(
     }
 
     init {
-        // Poll position/duration only while something is actually playing; while paused or idle
-        // the loop is suspended so the app does no periodic work (seeks are handled by the listener).
+        // Poll position/duration only while something is playing *and* a screen is displaying it.
+        //
+        // Gating on isPlaying alone still left the loop running through background playback: a
+        // locked phone playing a downloaded album has no Now Playing screen collecting these, so
+        // the main thread was woken twice a second for the length of the album to recompute state
+        // with no reader. Subscriber count is the honest signal — these two flows exist solely to
+        // drive a progress bar, so no subscriber means no reason to poll. Seeks are still reflected
+        // by the listener, and re-subscribing updates before its first delay, so a screen that
+        // comes back never shows a stale position.
         scope.launch {
-            _isPlaying.collectLatest { playing ->
-                if (!playing) return@collectLatest
-                while (currentCoroutineContext().isActive) {
-                    val c = activeController()
-                    if (c == null) {
-                        // Controller lost mid-playback (service killed): stop polling and reset
-                        // the flag, else its conflated true would keep the loop from restarting.
-                        _isPlaying.value = false
-                        break
+            combine(_isPlaying, positionSubscribers()) { playing, watched -> playing && watched }
+                .collectLatest { shouldPoll ->
+                    if (!shouldPoll) return@collectLatest
+                    while (currentCoroutineContext().isActive) {
+                        val c = activeController()
+                        if (c == null) {
+                            // Controller lost mid-playback (service killed): stop polling and reset
+                            // the flag, else its conflated true would keep the loop from restarting.
+                            _isPlaying.value = false
+                            break
+                        }
+                        _durationMs.value = c.duration.coerceAtLeast(0)
+                        _positionMs.value = c.currentPosition.coerceAtLeast(0)
+                        delay(PROGRESS_INTERVAL_MS)
                     }
-                    _durationMs.value = c.duration.coerceAtLeast(0)
-                    _positionMs.value = c.currentPosition.coerceAtLeast(0)
-                    delay(PROGRESS_INTERVAL_MS)
                 }
-            }
         }
     }
+
+    /**
+     * True while anything is collecting [positionMs] or [durationMs].
+     *
+     * Both are checked because a caller may want the duration alone; either one is a reader that
+     * would otherwise see a frozen value.
+     */
+    private fun positionSubscribers(): Flow<Boolean> =
+        combine(_positionMs.subscriptionCount, _durationMs.subscriptionCount) { position, duration ->
+            position + duration > 0
+        }
 
     /** Set the origin label for the next queue; call before [play] when starting a new source. */
     fun setSource(source: PlaybackSource) {

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/nowplaying/NowPlayingScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.StateFlow
 import pe.net.libre.mixtapehaven.di.appViewModel
 import pe.net.libre.mixtapehaven.ui.components.Artwork
 import pe.net.libre.mixtapehaven.ui.theme.Accent
@@ -58,15 +60,11 @@ fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
     val viewModel = appViewModel { NowPlayingViewModel(it.playerController, it.downloadManager) }
     val track by viewModel.nowPlaying.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
-    val positionMs by viewModel.positionMs.collectAsState()
-    val durationMs by viewModel.durationMs.collectAsState()
     val source by viewModel.source.collectAsState()
     val savingPercent by viewModel.savingPercent.collectAsState()
     val offlineReady by viewModel.offlineReady.collectAsState()
     val upNext by viewModel.upNext.collectAsState()
     val upNextOfflineReady by viewModel.upNextOfflineReady.collectAsState()
-
-    val progress = if (durationMs > 0) (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
 
     Column(
         modifier = modifier
@@ -135,25 +133,11 @@ fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
             OfflineStatus(savingPercent = savingPercent, offlineReady = offlineReady)
         }
 
-        // Progress
-        Column {
-            Slider(
-                value = progress,
-                onValueChange = viewModel::seekToFraction,
-                colors = SliderDefaults.colors(
-                    thumbColor = Accent,
-                    activeTrackColor = Accent,
-                    inactiveTrackColor = Surface2,
-                ),
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(formatTime(positionMs), style = MaterialTheme.typography.bodySmall, color = TextMuted)
-                Text(formatTime(durationMs), style = MaterialTheme.typography.bodySmall, color = TextMuted)
-            }
-        }
+        PlaybackProgress(
+            positionMs = viewModel.positionMs,
+            durationMs = viewModel.durationMs,
+            onSeek = viewModel::seekToFraction,
+        )
 
         // Controls
         Row(
@@ -209,6 +193,50 @@ fun NowPlayingScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 source = source,
                 offlineReady = upNextOfflineReady,
             )
+        }
+    }
+}
+
+/**
+ * The scrubber and its elapsed/total labels.
+ *
+ * Takes the flows rather than the values so the twice-a-second position tick is confined here.
+ * Collected at the screen's top level, every tick invalidated the whole body — hero artwork,
+ * track info, the controls row, the Up Next card — to move a slider and two labels.
+ *
+ * [collectAsStateWithLifecycle] rather than `collectAsState`, and that is a power decision, not a
+ * correctness one: these two subscriptions are what drive `PlayerController`'s 500 ms polling loop,
+ * and backgrounding the app does not leave the composition. A plain collector therefore keeps the
+ * subscription — and so the loop — alive at 2 Hz with the screen off, for as long as the music
+ * plays. Stopping below STARTED drops it, and the loop refreshes before its first delay when the
+ * screen comes back, so returning never shows a stale position.
+ */
+@Composable
+private fun PlaybackProgress(
+    positionMs: StateFlow<Long>,
+    durationMs: StateFlow<Long>,
+    onSeek: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val position by positionMs.collectAsStateWithLifecycle()
+    val duration by durationMs.collectAsStateWithLifecycle()
+    val progress = if (duration > 0) (position.toFloat() / duration).coerceIn(0f, 1f) else 0f
+    Column(modifier = modifier) {
+        Slider(
+            value = progress,
+            onValueChange = onSeek,
+            colors = SliderDefaults.colors(
+                thumbColor = Accent,
+                activeTrackColor = Accent,
+                inactiveTrackColor = Surface2,
+            ),
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(formatTime(position), style = MaterialTheme.typography.bodySmall, color = TextMuted)
+            Text(formatTime(duration), style = MaterialTheme.typography.bodySmall, color = TextMuted)
         }
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
@@ -134,10 +134,13 @@ fun VideoPlayerScreen(
 @Composable
 private fun PauseWhenScreenStops(onScreenStopped: () -> Unit) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val currentCallback by rememberUpdatedState(onScreenStopped)
+    // Read through .value rather than a `by` delegate. Both are the same read; the delegate is
+    // what static analysis flags as an unused variable, because the only use is a getValue call
+    // inside the observer lambda below and that is a hop it does not follow.
+    val currentCallback = rememberUpdatedState(onScreenStopped)
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_STOP) currentCallback()
+            if (event == Lifecycle.Event.ON_STOP) currentCallback.value()
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
@@ -64,6 +64,7 @@ fun VideoPlayerScreen(
     val error by viewModel.error.collectAsState()
     val upNext by viewModel.upNext.collectAsState()
     val buffering by viewModel.buffering.collectAsState()
+    val playbackActive by viewModel.playbackActive.collectAsState()
 
     // No background video service exists, so pause when the screen stops (Home button, lock);
     // otherwise audio would keep playing invisibly and the progress loop would churn the radio.
@@ -83,9 +84,12 @@ fun VideoPlayerScreen(
                     player = viewModel.player
                     setShowNextButton(false)
                     setShowPreviousButton(false)
-                    keepScreenOn = true
                 }
             },
+            // Only while something is actually playing. Pinning this on for as long as the screen
+            // is composed keeps the display — the phone's largest power draw — lit indefinitely
+            // behind a paused video, a "Playback failed" message, or a stream that never resolves.
+            update = { it.keepScreenOn = playbackActive },
             onRelease = { it.player = null },
             modifier = Modifier.fillMaxSize(),
         )

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerScreen.kt
@@ -86,10 +86,16 @@ fun VideoPlayerScreen(
                     setShowPreviousButton(false)
                 }
             },
-            // Only while something is actually playing. Pinning this on for as long as the screen
-            // is composed keeps the display — the phone's largest power draw — lit indefinitely
-            // behind a paused video, a "Playback failed" message, or a stream that never resolves.
-            update = { it.keepScreenOn = playbackActive },
+            // Awake while playing, and across the load: the player is STATE_IDLE until prepare(),
+            // so playbackActive alone would let the display sleep through the resolve hop — and
+            // the ON_STOP observer above turns that into a pause the user never asked for.
+            //
+            // What this stops is the display being pinned on for as long as the screen is
+            // composed: behind a paused video, or a "Playback failed" message, both of which can
+            // sit there for hours. A stream stuck buffering still holds it, deliberately — a
+            // rebuffer must not blank the picture — but that ends when the load times out into an
+            // error, which releases it.
+            update = { it.keepScreenOn = playbackActive || buffering },
             onRelease = { it.player = null },
             modifier = Modifier.fillMaxSize(),
         )

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
@@ -133,10 +133,17 @@ class VideoPlayerViewModel(
         }
     }
 
+    /**
+     * True while the player holds a prepared item that has not finished: playing, paused, or
+     * buffering. False before the first [prepareCurrentCandidate] and after an error (STATE_IDLE)
+     * or the end of an item (STATE_ENDED).
+     */
+    private fun holdsLiveItem(): Boolean =
+        player.playbackState == Player.STATE_READY || player.playbackState == Player.STATE_BUFFERING
+
     /** Recompute [playbackActive] from the player's current intent and state. */
     private fun refreshPlaybackActive() {
-        _playbackActive.value = player.playWhenReady &&
-            (player.playbackState == Player.STATE_READY || player.playbackState == Player.STATE_BUFFERING)
+        _playbackActive.value = player.playWhenReady && holdsLiveItem()
     }
 
     init {
@@ -270,10 +277,15 @@ class VideoPlayerViewModel(
     private suspend fun reportProgressLoop() {
         _playbackActive.collectLatest { active ->
             if (!active) {
-                // One report as playback stops, so the resume point lands. STATE_READY excludes the
-                // end-of-item and error transitions, which write their own STOPPED or show a
-                // message, and the initial idle emission before the first item is prepared.
-                if (player.playbackState == Player.STATE_READY) reportProgress(paused = true)
+                // One report as playback stops, so the resume point lands.
+                //
+                // Guarded on the same state pair as the flag itself, not on STATE_READY alone.
+                // Pausing during a rebuffer flips the flag from STATE_BUFFERING, and a READY-only
+                // guard dropped that report for good: the state settling to READY afterwards
+                // recomputes the flag to false, which conflates against the current false and
+                // never re-enters this collector. STATE_IDLE (never prepared, or errored) and
+                // STATE_ENDED stay excluded — those write their own STOPPED or show a message.
+                if (holdsLiveItem()) reportProgress(paused = true)
                 return@collectLatest
             }
             while (currentCoroutineContext().isActive) {

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import pe.net.libre.mixtapehaven.data.jellyfin.JellyfinRepository
@@ -68,6 +69,18 @@ class VideoPlayerViewModel(
     private val _buffering = MutableStateFlow(true)
     val buffering: StateFlow<Boolean> = _buffering.asStateFlow()
 
+    /**
+     * True while playback is live *or* about to be: playing, or rebuffering with the intent to
+     * resume. False once paused, ended, or errored.
+     *
+     * Two things hang off this, and both are power decisions rather than display state. The screen
+     * is held awake only while it is true, and [reportProgressLoop] only ticks while it is true.
+     * Buffering counts as live deliberately — a two-second rebuffer must not blank the screen —
+     * whereas [Player.isPlaying] would drop out for exactly that window.
+     */
+    private val _playbackActive = MutableStateFlow(false)
+    val playbackActive: StateFlow<Boolean> = _playbackActive.asStateFlow()
+
     /** The item currently on screen; changes when autoplay advances to the next episode. */
     private val _nowPlaying = MutableStateFlow<VideoItem?>(null)
     val nowPlaying: StateFlow<VideoItem?> = _nowPlaying.asStateFlow()
@@ -84,6 +97,7 @@ class VideoPlayerViewModel(
 
     private val listener = object : Player.Listener {
         override fun onPlaybackStateChanged(playbackState: Int) {
+            refreshPlaybackActive()
             when (playbackState) {
                 Player.STATE_BUFFERING -> _buffering.value = true
                 Player.STATE_READY -> {
@@ -99,6 +113,10 @@ class VideoPlayerViewModel(
             }
         }
 
+        // playWhenReady moves independently of the playback state — pausing mid-buffer changes only
+        // this — so both callbacks have to recompute the flag.
+        override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) = refreshPlaybackActive()
+
         override fun onPlayerError(error: PlaybackException) {
             // Direct play failed (e.g. a codec the device can't decode): fall through to the
             // transcoded candidate, keeping the position already reached.
@@ -113,6 +131,12 @@ class VideoPlayerViewModel(
                 _error.value = error.message ?: "Playback failed"
             }
         }
+    }
+
+    /** Recompute [playbackActive] from the player's current intent and state. */
+    private fun refreshPlaybackActive() {
+        _playbackActive.value = player.playWhenReady &&
+            (player.playbackState == Player.STATE_READY || player.playbackState == Player.STATE_BUFFERING)
     }
 
     init {
@@ -235,22 +259,28 @@ class VideoPlayerViewModel(
 
     /**
      * Report progress every [PROGRESS_REPORT_MS] while playing, plus exactly one paused report per
-     * pause (so the resume point lands) — then stay quiet to avoid indefinite idle network churn.
+     * pause (so the resume point lands) — then stay quiet.
+     *
+     * Gated on [playbackActive] rather than looping unconditionally: the ViewModel outlives the
+     * visible screen (backgrounding the app only pauses, it does not pop the back stack entry), so
+     * an unconditional loop keeps waking the CPU every ten seconds for as long as the player is on
+     * the stack — after a pause, after a terminal error, and for a video that ended with nothing to
+     * play next. [collectLatest] suspends the loop outright in all of those.
      */
     private suspend fun reportProgressLoop() {
-        var reportedPause = false
-        while (currentCoroutineContext().isActive) {
-            delay(PROGRESS_REPORT_MS)
-            val ready = player.playbackState == Player.STATE_READY
-            when {
-                ready && player.isPlaying -> {
-                    reportedPause = false
-                    reportProgress(paused = false)
-                }
-                ready && !reportedPause -> {
-                    reportedPause = true
-                    reportProgress(paused = true)
-                }
+        _playbackActive.collectLatest { active ->
+            if (!active) {
+                // One report as playback stops, so the resume point lands. STATE_READY excludes the
+                // end-of-item and error transitions, which write their own STOPPED or show a
+                // message, and the initial idle emission before the first item is prepared.
+                if (player.playbackState == Player.STATE_READY) reportProgress(paused = true)
+                return@collectLatest
+            }
+            while (currentCoroutineContext().isActive) {
+                delay(PROGRESS_REPORT_MS)
+                // False during a mid-playback rebuffer, which keeps the flag up but has no new
+                // position worth reporting.
+                if (player.isPlaying) reportProgress(paused = false)
             }
         }
     }

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/PlayerControllerSeamsTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/playback/PlayerControllerSeamsTest.kt
@@ -1,6 +1,7 @@
 package pe.net.libre.mixtapehaven.data.playback
 
 import androidx.compose.ui.graphics.Color
+import androidx.media3.common.C
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -58,5 +59,27 @@ class PlayerControllerSeamsTest {
     fun `shouldRefillQueue never refills an empty queue`() {
         // A stopped/cleared player reports itemCount 0; it must stay stopped, not refill.
         assertFalse(shouldRefillQueue(currentIndex = 0, itemCount = 0, threshold = 3))
+    }
+
+    @Test
+    fun `wakeModeForUri takes the WiFi lock only for streamed items`() {
+        assertEquals(C.WAKE_MODE_NETWORK, wakeModeForUri("https://jellyfin.example/Audio/1/stream"))
+        assertEquals(C.WAKE_MODE_NETWORK, wakeModeForUri("http://jellyfin.example/Audio/1/stream"))
+    }
+
+    @Test
+    fun `wakeModeForUri leaves the WiFi radio alone for a downloaded file`() {
+        // The drain this exists to stop: a downloaded album played with the screen off held the
+        // Wi-Fi radio out of power-save for its whole run, for bytes already on disk.
+        val saved = "file:///data/user/0/pe.net.libre.mixtapehaven/files/downloads/1"
+        assertEquals(C.WAKE_MODE_LOCAL, wakeModeForUri(saved))
+    }
+
+    @Test
+    fun `wakeModeForUri treats an unknown or missing scheme as local`() {
+        // Erring local costs a stream its WifiLock; erring network costs every offline listener
+        // battery for nothing. The cheaper lock is the safer default.
+        assertEquals(C.WAKE_MODE_LOCAL, wakeModeForUri(null))
+        assertEquals(C.WAKE_MODE_LOCAL, wakeModeForUri("content://media/external/audio/media/42"))
     }
 }


### PR DESCRIPTION
Started from a report of the phone heating up and the battery going down faster than usual. The first commit guessed at the video player; a battery-stats screenshot then showed **Mixtape at 11%, with 3 min of screen time against 1 hr 42 min in the background, playing downloaded music** — which redirected this to the audio path. Both are fixed here, but the WifiLock and position-poll fixes are the ones that match the reported symptom.

## What was draining

**A WifiLock held for local playback** (`PlaybackService`). The ExoPlayer was built with `setWakeMode(C.WAKE_MODE_NETWORK)` unconditionally. That mode adds a WifiLock on top of the CPU lock, holding the Wi-Fi radio out of power-save for as long as anything plays — right for a stream, pure waste for a file already on disk. Offline background playback is the longest, most common case where it buys nothing. The builder now takes `WAKE_MODE_LOCAL`, and a listener raises it per item only for an `http(s)` URI.

**The 500 ms position poll running with no reader** (`PlayerController`, `NowPlayingScreen`). #145 gated it on `isPlaying`, but `isPlaying` is exactly true during background playback, and the two flows it feeds exist only to drive the Now Playing progress bar. Two gaps: no gate on whether anything was collecting them, and `collectAsState` keeps collecting when the app is backgrounded, because stopping the Activity does not leave the composition. Now gated on `subscriptionCount` and collected with `collectAsStateWithLifecycle`, so it runs only while Now Playing is visible, foregrounded, and playing.

**The display pinned on by the video player** (`VideoPlayerScreen`). `keepScreenOn = true` was set in the `AndroidView` factory and never cleared, tying the screen lock to "the player screen is composed" rather than "something is playing" — so a paused video or a `Playback failed` message held the display lit indefinitely. Now driven from `playbackActive || buffering`.

**The video progress-report loop outliving its screen** (`VideoPlayerViewModel`). It woke every 10 s for the life of the ViewModel, which survives backgrounding, so it kept ticking after a pause, after a terminal error, and after a video ended with nothing queued. Now gated on `playbackActive`.

## Notes

- `playbackActive` is `playWhenReady && state in (READY, BUFFERING)`, not `Player.isPlaying`, so a rebuffer does not blank the screen mid-film. `|| buffering` additionally covers the pre-`prepare()` resolve window, where the player is `STATE_IDLE` — without it a slow resolve lets the display sleep, and the `ON_STOP` observer turns that into a pause the user never asked for.
- A stream stuck buffering still holds the screen lock. That is unchanged behaviour rather than something this PR fixes, and it is bounded in practice: a stalled load ends in an error within the source's read timeout, which releases it. A grace window was considered and rejected — it reintroduces a timer and needs a threshold nobody can pick well.
- Liveness detection for a killed session moved from the poll loop to `MediaController.Listener.onDisconnected`, since the loop is now subscriber-gated and would miss it in exactly the backgrounded case where the service is most likely to be reclaimed.
- `wakeModeForUri` is a pure seam alongside `resolvePlayables` / `shouldRefillQueue`, covered for the streamed, downloaded, and unknown-scheme cases. Unknown schemes resolve to `WAKE_MODE_LOCAL`: erring local costs a stream its WifiLock, erring network costs every offline listener battery for nothing.
- Merged `main` rather than rebasing. The one conflict was in `PlaybackService.onCreate`, where #162's session activity and this branch's wake-mode listener both landed — both kept. #163's `fail()` helper clears `_buffering` on every terminal load path, which is what the `|| buffering` screen lock relies on to release, so the two compose correctly.

## Testing

`./gradlew compileDebugKotlin testDebugUnitTest detekt` green — 120 unit tests, including three new `wakeModeForUri` cases.

**Not measured on a device.** Every fix here is reasoned from the code, and none of it has been checked against a real battery trace. The WifiLock is the largest of the four by some margin, but the honest next step is a charge cycle with the built APK before trusting any of these numbers.