### PR TITLE
Fix the reachability gate's misattributions and dead taps

### DIFF
--- a/app/src/main/java/pe/net/libre/mixtapehaven/data/network/ServerAvailability.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/data/network/ServerAvailability.kt
@@ -1,8 +1,10 @@
 package pe.net.libre.mixtapehaven.data.network
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -43,8 +45,11 @@ class ServerAvailability(
     @Volatile
     private var lastSuccessAtMs: Long? = null
 
-    /** Serializes pings so a burst of taps costs one request, not one each. */
+    /** Guards [inFlightPing] so a burst of taps costs one request, not one each. */
     private val pingLock = Mutex()
+
+    /** The ping currently in flight, if any, for later callers to join instead of starting their own. */
+    private var inFlightPing: Deferred<Boolean>? = null
 
     init {
         scope.launch {
@@ -87,12 +92,30 @@ class ServerAvailability(
             false
         }
         hasFreshSuccess() -> true
-        // A ping may have landed while this call waited for the lock, hence the second look —
-        // short-circuiting means the ping is skipped when it did.
-        else -> pingLock.withLock { hasFreshSuccess() || pingNow() }
+        else -> sharedPing()
     }
 
-    /** One ping, recorded either way. Callers hold [pingLock]. */
+    /**
+     * One ping per burst, shared by everyone waiting on it.
+     *
+     * Serializing the callers instead would have each of them re-ping on a refusal, since a failed
+     * ping leaves no fresh success for the next one to short-circuit on: four taps on a dimmed card
+     * would cost four round trips and four timeouts back to back, and the last tap would wait for
+     * all of them. Joining the request already in flight costs one.
+     */
+    private suspend fun sharedPing(): Boolean {
+        val ping = pingLock.withLock {
+            // A ping may have landed while this call waited for the lock, hence the second look —
+            // short-circuiting means the ping is skipped when it did.
+            if (hasFreshSuccess()) return true
+            // Runs in [scope] rather than the caller's: a caller that gives up (navigated away)
+            // must not cancel the answer the other waiters are still holding out for.
+            inFlightPing?.takeIf { it.isActive } ?: scope.async { pingNow() }.also { inFlightPing = it }
+        }
+        return ping.await()
+    }
+
+    /** One ping, recorded either way. */
     private suspend fun pingNow(): Boolean {
         // Running out of the budget (null) is as good as a refusal: the server did not answer.
         val answered = withTimeoutOrNull(PING_TIMEOUT_MS) { runCatching { ping() }.getOrDefault(false) } ?: false
@@ -119,7 +142,17 @@ class ServerAvailability(
         /** How long a successful exchange stands in for a ping. */
         const val FRESH_MS = 30_000L
 
-        /** Ping budget. Long enough for a slow LAN, short enough that a tap still feels answered. */
-        const val PING_TIMEOUT_MS = 3_000L
+        /**
+         * Ping budget.
+         *
+         * Running out of it counts as a refusal, which is what makes the length matter: the case
+         * this whole class exists for — a LAN address from off the LAN, a VPN that is down — has no
+         * one to send a refusal, so it *only* ever shows up as a timeout. Treating that as
+         * inconclusive would let the black frame back in. The cost is the opposite mistake: a
+         * server that would have answered, just slowly, is refused. So the budget is generous
+         * enough to cover a cold DNS + TCP + TLS handshake over a weak mobile connection, and the
+         * callers show that a tap is being worked on rather than leaving it to feel dropped.
+         */
+        const val PING_TIMEOUT_MS = 5_000L
     }
 }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/ContinueCard.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/components/ContinueCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CloudOff
 import androidx.compose.material.icons.outlined.DownloadDone
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -54,6 +55,9 @@ private const val UNAVAILABLE_ALPHA = 0.45f
  * It is dimmed and says so instead of the time left, because a card that looks identical to a
  * playable one turns a tap into an apparent no-op. It stays clickable so the tap can explain itself.
  *
+ * [pending] covers the seconds that explaining takes: confirming a dimmed card against the server
+ * is a round trip, and without a mark on the card the tap looks as dropped as the one this replaced.
+ *
  * Mirrors the "Continue Card" component in happypath.pen.
  */
 @Composable
@@ -63,23 +67,28 @@ fun ContinueCard(
     modifier: Modifier = Modifier,
     downloaded: Boolean = false,
     unavailable: Boolean = false,
+    pending: Boolean = false,
 ) {
-    val meta = if (unavailable) {
-        listOfNotNull(video.seasonEpisodeLabel, "Not downloaded").joinToString(" · ")
-    } else {
-        listOfNotNull(
+    val meta = when {
+        pending -> listOfNotNull(video.seasonEpisodeLabel, "Checking your server…").joinToString(" · ")
+        unavailable -> listOfNotNull(video.seasonEpisodeLabel, "Not downloaded").joinToString(" · ")
+        else -> listOfNotNull(
             video.seasonEpisodeLabel,
             formatTimeLeft(video.runtimeMs, video.resumePositionMs).ifEmpty { null },
         ).joinToString(" · ")
     }
-    val clickLabel = if (unavailable) "${video.title}, not available right now" else "Resume ${video.title}"
+    val clickLabel = when {
+        pending -> "${video.title}, checking whether it can play"
+        unavailable -> "${video.title}, not available right now"
+        else -> "Resume ${video.title}"
+    }
     Column(
         modifier = modifier
             .width(CARD_WIDTH)
             .clickable(role = Role.Button, onClickLabel = clickLabel, onClick = onClick),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        ContinueStill(video, dimmed = unavailable)
+        ContinueStill(video, dimmed = unavailable, pending = pending)
         Text(
             video.title,
             style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
@@ -88,14 +97,14 @@ fun ContinueCard(
             overflow = TextOverflow.Ellipsis,
         )
         if (meta.isNotEmpty()) {
-            ContinueMeta(meta = meta, downloaded = downloaded, unavailable = unavailable)
+            ContinueMeta(meta = meta, downloaded = downloaded, unavailable = unavailable && !pending)
         }
     }
 }
 
 /** The 16:9 still with the watched-progress bar across its bottom edge. */
 @Composable
-private fun ContinueStill(video: VideoItem, dimmed: Boolean = false) {
+private fun ContinueStill(video: VideoItem, dimmed: Boolean = false, pending: Boolean = false) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -118,6 +127,22 @@ private fun ContinueStill(video: VideoItem, dimmed: Boolean = false) {
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize(),
             )
+        }
+        if (pending) {
+            // Over a scrim rather than beside the meta line: the spinner has to be findable at a
+            // glance on a rail the user is already tapping again.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.45f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(
+                    color = Accent,
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
         }
         ProgressTrack(
             fraction = video.progressFraction,

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import pe.net.libre.mixtapehaven.R
 import pe.net.libre.mixtapehaven.di.appViewModel
 import androidx.compose.foundation.lazy.LazyRow
@@ -84,6 +86,9 @@ fun HomeScreen(
     val nowPlayingTrack by viewModel.nowPlaying.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
     val hasDownloads = state.onDevice.isNotEmpty()
+    // Home's own back stack entry, so "still in front of the user" survives navigation, not just
+    // the app being backgrounded.
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
     val snackbarHostState = remember { SnackbarHostState() }
     LaunchedEffect(viewModel) {
         viewModel.snackbarMessages.collect { message -> snackbarHostState.showSnackbar(message) }
@@ -121,7 +126,7 @@ fun HomeScreen(
                     onOpenDownloads = onOpenDownloads,
                     onOpenSettings = onOpenSettings,
                     videoNav = videoNav,
-                    onResumeVideo = { viewModel.resumeVideo(it, videoNav.onResumeVideo) },
+                    onResumeVideo = resumeVideoAction(viewModel, lifecycle, videoNav.onResumeVideo),
                     onPlayTrack = { viewModel.playOnDevice(it); onOpenNowPlaying() },
                     onPlayAlbum = { viewModel.playAlbum(it); onOpenNowPlaying() },
                     onRetry = viewModel::load,
@@ -199,6 +204,23 @@ private data class HomeSectionActions(
 )
 
 /**
+ * A Continue watching tap, with the resulting navigation gated on [lifecycle].
+ *
+ * A title that needs the server is confirmed against it before the player opens, which is a round
+ * trip, and Home stays composed behind whatever the user opens in the meantime. Navigating on a
+ * late answer would drop the player on top of the screen they moved to, so the tap lapses instead.
+ */
+private fun resumeVideoAction(
+    viewModel: HomeViewModel,
+    lifecycle: Lifecycle,
+    onResumeVideo: (String) -> Unit,
+): (VideoItem) -> Unit = { video ->
+    viewModel.resumeVideo(video) { id ->
+        if (lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) onResumeVideo(id)
+    }
+}
+
+/**
  * The library sections of Home, in design order: saved tracks, Continue watching, Movies & shows,
  * and the Recently added grid.
  */
@@ -220,6 +242,7 @@ private fun HomeSections(
             videos = state.continueWatching,
             downloadedIds = state.downloadedVideoIds,
             serverReachable = state.serverReachable,
+            pendingId = state.resumePendingId,
             onVideoClick = actions.onResumeVideo,
         )
     }
@@ -320,7 +343,7 @@ private fun OnDeviceSection(
  *
  * With the server out of reach ([serverReachable] false) the rail keeps listing everything, but
  * titles without a saved copy are marked unplayable rather than left looking like the downloaded
- * ones.
+ * ones. [pendingId] is the one whose tap is currently being confirmed against the server.
  *
  * The plain title (no "See all") matches the design: the rail is the complete list.
  */
@@ -329,6 +352,7 @@ private fun ContinueWatchingSection(
     videos: List<VideoItem>,
     downloadedIds: Set<String>,
     serverReachable: Boolean,
+    pendingId: String?,
     onVideoClick: (VideoItem) -> Unit,
 ) {
     SectionHeader(title = "Continue watching")
@@ -339,6 +363,7 @@ private fun ContinueWatchingSection(
                 video = video,
                 downloaded = downloaded,
                 unavailable = !serverReachable && !downloaded,
+                pending = video.id == pendingId,
                 onClick = { onVideoClick(video) },
             )
         }

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeScreen.kt
@@ -204,20 +204,28 @@ private data class HomeSectionActions(
 )
 
 /**
- * A Continue watching tap, with the resulting navigation gated on [lifecycle].
+ * A Continue watching tap, with the navigation that follows a *deferred* one gated on [lifecycle].
  *
  * A title that needs the server is confirmed against it before the player opens, which is a round
  * trip, and Home stays composed behind whatever the user opens in the meantime. Navigating on a
  * late answer would drop the player on top of the screen they moved to, so the tap lapses instead.
+ *
+ * `STARTED` rather than `RESUMED`, because the question is whether Home is still the screen in
+ * front of the user, not whether it holds focus: a back stack entry sits at `STARTED` in
+ * split-screen and mid-transition, and refusing there would make live taps do nothing — the very
+ * thing this rail is meant to stop. Navigation-compose drops a covered entry below `STARTED`, so
+ * the case worth refusing is still refused.
  */
 private fun resumeVideoAction(
     viewModel: HomeViewModel,
     lifecycle: Lifecycle,
     onResumeVideo: (String) -> Unit,
 ): (VideoItem) -> Unit = { video ->
-    viewModel.resumeVideo(video) { id ->
-        if (lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) onResumeVideo(id)
-    }
+    viewModel.resumeVideo(
+        video = video,
+        stillInFront = { lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED) },
+        onResume = onResumeVideo,
+    )
 }
 
 /**

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -4,8 +4,10 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -231,8 +233,13 @@ class HomeViewModel(
      * That check is slow enough to be tapped through, so one runs at a time: a repeat tap on the
      * title already being checked is dropped rather than queued (four taps used to mean four pings
      * and the same message four times), and moving to a different title abandons the first.
+     *
+     * [stillInFront] is asked only on that slow path, and only about navigating: an answer can
+     * arrive after the user has moved on, and opening the player over the screen they went to is
+     * worse than letting the tap lapse. The immediate path never consults it — a downloaded title
+     * resumes on the tap, whatever the screen is doing.
      */
-    fun resumeVideo(video: VideoItem, onResume: (String) -> Unit) {
+    fun resumeVideo(video: VideoItem, stillInFront: () -> Boolean = { true }, onResume: (String) -> Unit) {
         val state = _state.value
         if (canPlayNow(video.id, state.serverReachable, state.downloadedVideoIds)) {
             onResume(video.id)
@@ -241,20 +248,28 @@ class HomeViewModel(
         if (state.resumePendingId == video.id) return
         pendingResume?.cancel()
         _state.update { it.copy(resumePendingId = video.id) }
-        pendingResume = viewModelScope.launch {
+        // Started only once [pendingResume] holds it, so the check below identifies this job rather
+        // than whatever the field happened to hold when the body first ran.
+        val job = viewModelScope.launch(start = CoroutineStart.LAZY) {
             try {
                 if (serverAvailability.check()) {
-                    onResume(video.id)
+                    if (stillInFront()) onResume(video.id)
                     return@launch
                 }
                 diagnostics.log(TAG, "Blocked resume of ${video.id}: server unreachable, no saved copy")
                 _snackbarMessages.send(unavailableMessage(video.title, hasNetwork = serverAvailability.hasNetwork()))
             } finally {
-                // Only if this tap is still the pending one: a tap on another title has already
-                // published its own wait, and clearing that would mark its card as idle mid-check.
-                _state.update { if (it.resumePendingId == video.id) it.copy(resumePendingId = null) else it }
+                // Keyed on the job, not the id: A -> B -> A within one check window puts the same
+                // id back on screen for a *different* job, and clearing on id alone would take the
+                // spinner off a check that is still running.
+                if (pendingResume == currentCoroutineContext()[Job]) {
+                    pendingResume = null
+                    _state.update { it.copy(resumePendingId = null) }
+                }
             }
         }
+        pendingResume = job
+        job.start()
     }
 
     fun playPause() = playerController.playPause()

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -60,6 +61,12 @@ class HomeViewModel(
          * Starts optimistic so nothing is painted as unplayable before anything has failed.
          */
         val serverReachable: Boolean = true,
+        /**
+         * The Continue watching title whose tap is waiting on a reachability check, if any. The
+         * check can take seconds, and an unmarked card gives a tap nothing to show for itself —
+         * which is the "did that do anything?" this rail is trying to stop causing.
+         */
+        val resumePendingId: String? = null,
     )
 
     private val _state = MutableStateFlow(UiState())
@@ -76,6 +83,9 @@ class HomeViewModel(
 
     /** One-shot messages for transient UI feedback (e.g. a Snackbar), not persisted in [state]. */
     val snackbarMessages: Flow<String> = _snackbarMessages.receiveAsFlow()
+
+    /** The reachability check behind the current Continue watching tap; at most one runs. */
+    private var pendingResume: Job? = null
 
     init {
         load()
@@ -217,6 +227,10 @@ class HomeViewModel(
      * A downloaded title never waits on anything. Otherwise the dimmed state is only a belief, so
      * it is confirmed with [ServerAvailability.check] before refusing: a server that came back
      * (VPN reconnected) must play on the first tap, not after a manual reload.
+     *
+     * That check is slow enough to be tapped through, so one runs at a time: a repeat tap on the
+     * title already being checked is dropped rather than queued (four taps used to mean four pings
+     * and the same message four times), and moving to a different title abandons the first.
      */
     fun resumeVideo(video: VideoItem, onResume: (String) -> Unit) {
         val state = _state.value
@@ -224,13 +238,22 @@ class HomeViewModel(
             onResume(video.id)
             return
         }
-        viewModelScope.launch {
-            if (serverAvailability.check()) {
-                onResume(video.id)
-                return@launch
+        if (state.resumePendingId == video.id) return
+        pendingResume?.cancel()
+        _state.update { it.copy(resumePendingId = video.id) }
+        pendingResume = viewModelScope.launch {
+            try {
+                if (serverAvailability.check()) {
+                    onResume(video.id)
+                    return@launch
+                }
+                diagnostics.log(TAG, "Blocked resume of ${video.id}: server unreachable, no saved copy")
+                _snackbarMessages.send(unavailableMessage(video.title, hasNetwork = serverAvailability.hasNetwork()))
+            } finally {
+                // Only if this tap is still the pending one: a tap on another title has already
+                // published its own wait, and clearing that would mark its card as idle mid-check.
+                _state.update { if (it.resumePendingId == video.id) it.copy(resumePendingId = null) else it }
             }
-            diagnostics.log(TAG, "Blocked resume of ${video.id}: server unreachable, no saved copy")
-            _snackbarMessages.send(unavailableMessage(video.title, hasNetwork = serverAvailability.hasNetwork()))
         }
     }
 

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
@@ -84,6 +84,12 @@ class VideoPlayerViewModel(
     /** True once any candidate actually played; gates the STOPPED report in [onCleared]. */
     private var reachedReady = false
 
+    /**
+     * Bumped by every [startItem]. Work started for one item and finished after the next one began
+     * checks this before touching shared state, so a slow answer cannot land on the wrong episode.
+     */
+    private var loadGeneration = 0
+
     private val listener = object : Player.Listener {
         override fun onPlaybackStateChanged(playbackState: Int) {
             when (playbackState) {
@@ -91,6 +97,10 @@ class VideoPlayerViewModel(
                 Player.STATE_READY -> {
                     reachedReady = true
                     _buffering.value = false
+                    // Bytes arriving over the network is proof the server answers, and it is free:
+                    // folding it in keeps the fresh window warm for the whole session, so the next
+                    // episode's gate can skip its ping instead of making every hop wait on one.
+                    if (needsServer(candidates)) serverAvailability.report(success = true)
                 }
                 Player.STATE_ENDED -> {
                     _buffering.value = false
@@ -117,8 +127,13 @@ class VideoPlayerViewModel(
                 // away mid-playback (VPN dropped, walked off the LAN). Confirm in the background and
                 // swap in the message that names the real problem; the raw one stands until then.
                 if (needsServer(candidates)) {
+                    val generation = loadGeneration
                     viewModelScope.launch {
-                        if (!serverAvailability.check()) {
+                        val unreachable = !serverAvailability.check()
+                        // The check can outlive the item that failed: a tap on Up Next during it
+                        // may already be playing a downloaded copy by now, and painting this
+                        // message over that would accuse a working screen of being broken.
+                        if (unreachable && generation == loadGeneration) {
                             _error.value = unreachableMessage(hasNetwork = serverAvailability.hasNetwork())
                         }
                     }
@@ -147,6 +162,7 @@ class VideoPlayerViewModel(
      * unguarded — and a spinner turning forever reads worse than the black frame it replaced.
      */
     private suspend fun startItem(id: String) {
+        loadGeneration++
         // Cleared up front so a hop that fails below cannot leave the pill pointing at the
         // previous episode's successor, and so it never shows a stale value while loadUpNext runs.
         _upNext.value = null
@@ -172,35 +188,57 @@ class VideoPlayerViewModel(
             // An item that will not resolve is usually the server, not the item: check before
             // blaming the title, so the LAN-only/VPN case is named for what it is.
             val reachable = serverAvailability.check()
+            stopPlayback()
             fail(if (reachable) "Could not load this title" else unreachableMessage(serverAvailability.hasNetwork()))
             return
         }
-        _nowPlaying.value = item
-        candidates = resolveSources(id)
-        candidateIndex = 0
-        reachedReady = false
-        val blocker = playbackBlocker()
+        val sources = resolveSources(id)
+        val blocker = playbackBlocker(sources)
         if (blocker != null) {
+            // Nothing here will play, and on a user-driven hop the previous episode is still
+            // playing right now. Stop it before [_nowPlaying] moves on: [reportProgressLoop] pairs
+            // the player's playhead with whatever [_nowPlaying] holds, so leaving the old stream
+            // running under the new id would save the old episode's position as the new one's
+            // resume point — locally and on the server.
+            stopPlayback()
+            _nowPlaying.value = item
             fail(blocker)
             return
         }
+        _nowPlaying.value = item
+        candidates = sources
+        candidateIndex = 0
+        reachedReady = false
         prepareCurrentCandidate(startMs = resolved.positionMs)
         progressStore.record(item, resolved.positionMs, player.duration.durationOrZero(), VideoPlaybackEvent.STARTED)
         _upNext.value = loadUpNext(item)
     }
 
     /**
-     * Why the resolved [candidates] cannot play, or null when they can.
+     * Why [sources] cannot play, or null when they can. Asked before any of it is published, so a
+     * refusal leaves no half-switched state behind.
      *
      * The server check is what keeps the screen from sitting on a black frame while each candidate
      * fails its own connection attempt in turn. It is skipped entirely for a saved copy, so offline
      * playback of a download costs nothing.
      */
-    private suspend fun playbackBlocker(): String? = when {
-        candidates.isEmpty() -> "No playable source for this title"
-        needsServer(candidates) && !serverAvailability.check() ->
+    private suspend fun playbackBlocker(sources: List<String>): String? = when {
+        sources.isEmpty() -> "No playable source for this title"
+        needsServer(sources) && !serverAvailability.check() ->
             unreachableMessage(hasNetwork = serverAvailability.hasNetwork())
         else -> null
+    }
+
+    /**
+     * Wind the player down to nothing, so a load that ends in an error leaves no stream running
+     * behind the message and no playhead for the progress reports to misattribute.
+     */
+    private fun stopPlayback() {
+        player.stop()
+        player.clearMediaItems()
+        candidates = emptyList()
+        candidateIndex = 0
+        reachedReady = false
     }
 
     /** End the load with [message] on screen; the buffering indicator must not outlive it. */

--- a/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/pe/net/libre/mixtapehaven/ui/screens/video/VideoPlayerViewModel.kt
@@ -12,9 +12,11 @@ import androidx.media3.exoplayer.ExoPlayer
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -85,22 +87,31 @@ class VideoPlayerViewModel(
     private var reachedReady = false
 
     /**
-     * Bumped by every [startItem]. Work started for one item and finished after the next one began
-     * checks this before touching shared state, so a slow answer cannot land on the wrong episode.
+     * Bumped by every [startItem]. Work that runs outside the load itself — the reachability check
+     * behind a playback failure — checks this before touching shared state, so a slow answer cannot
+     * land on the episode that replaced the one it was asked about.
      */
     private var loadGeneration = 0
+
+    /** The load in flight, so a new hop can replace it rather than race it. See [startLoad]. */
+    private var loadJob: Job? = null
 
     private val listener = object : Player.Listener {
         override fun onPlaybackStateChanged(playbackState: Int) {
             when (playbackState) {
                 Player.STATE_BUFFERING -> _buffering.value = true
                 Player.STATE_READY -> {
+                    // Only the *first* ready of a load can be taken as evidence: it is the one the
+                    // network had to serve. Every later BUFFERING -> READY may be a seek back into
+                    // what the buffer already holds, which says nothing about a server that could
+                    // have died minutes ago — and vouching for it there would hand back the black
+                    // frame the check exists to prevent.
+                    val firstReady = !reachedReady
                     reachedReady = true
                     _buffering.value = false
-                    // Bytes arriving over the network is proof the server answers, and it is free:
-                    // folding it in keeps the fresh window warm for the whole session, so the next
+                    // Free evidence, so the fresh window stays warm for the session and the next
                     // episode's gate can skip its ping instead of making every hop wait on one.
-                    if (needsServer(candidates)) serverAvailability.report(success = true)
+                    if (firstReady && needsServer(candidates)) serverAvailability.report(success = true)
                 }
                 Player.STATE_ENDED -> {
                     _buffering.value = false
@@ -147,9 +158,30 @@ class VideoPlayerViewModel(
         musicController.pause()
         player.addListener(listener)
         player.playWhenReady = true
-        viewModelScope.launch {
-            startItem(itemId)
-            reportProgressLoop()
+        startLoad { startItem(itemId) }
+        // Its own coroutine: the reporting loop outlives every hop, so it must not be the thing a
+        // hop cancels. It reads the player's state each tick, so it is harmless before the first
+        // load lands.
+        viewModelScope.launch { reportProgressLoop() }
+    }
+
+    /**
+     * Run [block] as *the* load, replacing whatever was still running.
+     *
+     * Hops can be asked for faster than they complete — a next-button tap while the previous one is
+     * still resolving, or one landing exactly as the episode ends — and two loads in flight would
+     * interleave their publishes: whichever [resolveSources] returned last would win on [candidates]
+     * while the other had already won on [_nowPlaying], pairing a stream with the wrong episode's
+     * id. Only one load exists at a time, so there is nothing to interleave.
+     */
+    private fun startLoad(block: suspend () -> Unit) {
+        // Cancelled here rather than inside the new job: a third request must supersede the second
+        // even if the second never got to run its own cancellation.
+        val previous = loadJob?.also { it.cancel() }
+        loadJob = viewModelScope.launch {
+            // Joined so the outgoing load is fully unwound before this one starts publishing.
+            previous?.join()
+            block()
         }
     }
 
@@ -174,7 +206,8 @@ class VideoPlayerViewModel(
         // flag is raised here rather than waiting for STATE_BUFFERING.
         _buffering.value = true
         val failure = runCatching { prepareItem(id) }.exceptionOrNull() ?: return
-        // Cancellation is the scope shutting down, not a load failure; let it unwind.
+        // Cancellation is the scope shutting down or a newer hop taking over, not a load failure:
+        // let it unwind rather than painting an error over the load that replaced it.
         if (failure is CancellationException) throw failure
         _buffering.value = false
         _error.value = "Could not load this title"
@@ -188,12 +221,18 @@ class VideoPlayerViewModel(
             // An item that will not resolve is usually the server, not the item: check before
             // blaming the title, so the LAN-only/VPN case is named for what it is.
             val reachable = serverAvailability.check()
+            // Superseded while the check ran: the hop that replaced this one owns the player now,
+            // and stopping it here would kill the load the user is actually waiting on.
+            currentCoroutineContext().ensureActive()
             stopPlayback()
             fail(if (reachable) "Could not load this title" else unreachableMessage(serverAvailability.hasNetwork()))
             return
         }
         val sources = resolveSources(id)
         val blocker = playbackBlocker(sources)
+        // Last chance to notice a hop that replaced this one: everything below is synchronous, so
+        // an unwanted load would publish in full before the coroutine next looked at its own state.
+        currentCoroutineContext().ensureActive()
         if (blocker != null) {
             // Nothing here will play, and on a user-driven hop the previous episode is still
             // playing right now. Stop it before [_nowPlaying] moves on: [reportProgressLoop] pairs
@@ -266,7 +305,7 @@ class VideoPlayerViewModel(
     private fun onPlaybackEnded() {
         val finished = _nowPlaying.value ?: return
         val next = _upNext.value
-        viewModelScope.launch {
+        startLoad {
             // Finalize the finished item first so it leaves Continue watching before the next
             // episode's own STARTED report lands.
             progressStore.record(
@@ -286,7 +325,7 @@ class VideoPlayerViewModel(
         val current = _nowPlaying.value
         val positionMs = player.currentPosition.coerceAtLeast(0)
         val durationMs = player.duration.durationOrZero()
-        viewModelScope.launch {
+        startLoad {
             if (current != null) {
                 progressStore.record(
                     current,

--- a/app/src/test/java/pe/net/libre/mixtapehaven/data/network/ServerAvailabilityTest.kt
+++ b/app/src/test/java/pe/net/libre/mixtapehaven/data/network/ServerAvailabilityTest.kt
@@ -122,6 +122,56 @@ class ServerAvailabilityTest {
         assertEquals(1, ping.calls)
     }
 
+    /**
+     * A refusal leaves no fresh success behind, so callers that merely serialized would each re-ping
+     * — the repeat-tap case, where four taps on a dimmed card used to mean four timeouts in a row.
+     */
+    @Test
+    fun `concurrent checks share one failing ping`() = runTest {
+        val ping = FakePing(answers = false, delayMs = 500)
+        val availability = availability(ping = ping)
+
+        val results = coroutineScope {
+            val first = async { availability.check() }
+            val second = async { availability.check() }
+            val third = async { availability.check() }
+            listOf(first.await(), second.await(), third.await())
+        }
+
+        assertEquals(listOf(false, false, false), results)
+        assertEquals(1, ping.calls)
+    }
+
+    /** Sharing must not outlive the request: the tap after it gets a current answer, not a cached one. */
+    @Test
+    fun `a later check starts a new ping`() = runTest {
+        val ping = FakePing(answers = false)
+        val availability = availability(ping = ping)
+
+        assertFalse(availability.check())
+        assertFalse(availability.check())
+
+        assertEquals(2, ping.calls)
+    }
+
+    /** A caller that gives up must not take the answer away from the ones still waiting. */
+    @Test
+    fun `abandoning a check leaves the shared ping running`() = runTest {
+        val ping = FakePing(delayMs = 500)
+        val availability = availability(ping = ping)
+
+        val joined = coroutineScope {
+            val abandoned = async { availability.check() }
+            val waiting = async { availability.check() }
+            runCurrent()
+            abandoned.cancel()
+            waiting.await()
+        }
+
+        assertTrue(joined)
+        assertEquals(1, ping.calls)
+    }
+
     @Test
     fun `losing the network marks the server unreachable`() = runTest {
         val monitor = FakeNetworkMonitor()


### PR DESCRIPTION
Follow-up to #163, acting on [its post-merge review](https://github.com/jaxkodex/mixtapehaven-android/pull/163#pullrequestreview-4891099337). Three of the four findings were real bugs; the fourth is answered in part, and the part I disagreed with is explained below. A [second review round](https://github.com/jaxkodex/mixtapehaven-android/pull/165#pullrequestreview-4891299289) on this branch found four more, all fixed in the second commit — summarised at the end.

## A blocked hop no longer misattributes the previous episode's playhead

[Finding 1](https://github.com/jaxkodex/mixtapehaven-android/pull/163#discussion_r3743421703). `prepareItem` published `_nowPlaying` (and reset `candidates`/`reachedReady`) *before* `playbackBlocker()` could refuse. On a user-driven hop — tap Up Next with the server gone — E1 kept playing while `_nowPlaying` already pointed at E2, and `reportProgressLoop`, which pairs the player's live playhead with whatever `_nowPlaying` holds, wrote E1's position as **E2's** resume point every 10s, locally and to the server.

Sources are now resolved and the blocker computed before anything is published, and a load that ends in an error calls `stopPlayback()` — so no stream keeps running behind the message and no playhead is left for the progress reports to misattribute. The same stop now covers the "item won't resolve" path, which had the same shape.

## The background reachability check can't paint over a later item

[Finding 2](https://github.com/jaxkodex/mixtapehaven-android/pull/163#discussion_r3743422255). The `check()` launched from `onPlayerError` wrote `_error` with no guard, so a check begun on a failed stream could resolve seconds later and stamp "Can't reach your server" over a downloaded episode that had since started playing fine — with nothing left to clear it. A `loadGeneration`, bumped by every `startItem`, is captured at launch and re-checked before the write.

## Repeat taps on a dimmed card cost one check, not one each

[Finding 4](https://github.com/jaxkodex/mixtapehaven-android/pull/163#discussion_r3743423052). At most one confirmation runs at a time: a repeat tap on the title already being checked is dropped, moving to a different title abandons the first, and `UiState.resumePendingId` drives a spinner and a "Checking your server…" meta line on the card — so the tap that used to look dead for the duration now shows its work. The navigation that follows a *deferred* tap is gated on Home's own back-stack lifecycle, so a late answer no longer pushes the player on top of whatever screen the user moved to.

## Fewer taps reach the gate, and the ones that do wait less

[Finding 3](https://github.com/jaxkodex/mixtapehaven-android/pull/163#discussion_r3743422729), partly. Three changes, all aimed at the false-refusal risk the review describes:

- A server-backed stream reaching its first `STATE_READY` calls `report(true)`. Bytes arriving is proof the server answers, it costs nothing, and it keeps the fresh window warm across a session so each autoplay hop no longer waits on its own ping.
- Concurrent callers now join the ping already in flight rather than serializing behind a mutex. A refusal leaves no fresh success to short-circuit on, so four taps used to mean four round trips and four timeouts back to back, the last tap waiting for all of them.
- The ping budget goes 3s → 5s, which is the cold DNS + TCP + TLS case on a weak mobile connection.

**What I did not change:** treating a timed-out ping as inconclusive. The case this whole class exists for — a LAN address from off the LAN, a VPN that is down — has nobody to send a refusal, so it *only* ever surfaces as a timeout. Letting playback proceed on one would put the black frame back for the exact scenario the feature targets. The trade-off is real, so the constant now documents it, and the fixes above narrow the window in which it can bite.

## Second review round

Four more findings, all real, all fixed in `0293ea1`:

1. **Two loads could be in flight at once.** `playNext` reads `_upNext` synchronously and suspends on the STOPPED record before reaching `startItem`, so two quick taps both captured the same non-null next; an ENDED racing a tap did the same with different ids — the interleaved-publish shape the first commit set out to close. Hops now go through `startLoad()`, which cancels the load in flight and joins it before starting, and `prepareItem` calls `ensureActive()` before publishing so a doomed load can't touch the player or write a STARTED for an episode nobody will see.
2. **The lifecycle gate was too wide.** It wrapped the synchronous resume too, and `RESUMED` is stricter than "the user can tap this" — a back stack entry sits at `STARTED` in split-screen and mid-transition, where every Continue watching tap would have been a silent no-op. `resumeVideo` now takes `stillInFront`, consulted only before navigating on a late answer, and Home passes `STARTED`.
3. **The pending-tap guard keyed on video id rather than the job.** A → B → A within one check window cleared the spinner out from under a still-running check. Now keyed on job identity, with the job started `LAZY` so its body can't observe `pendingResume` before it is assigned.
4. **`report(true)` could be fed by a buffered seek.** `onPlaybackStateChanged` sees every transition, and a seek back into buffered content reaches `READY` without touching the network — refreshing the freshness window on minutes-old evidence, which is how a dead server gets waved through. It now fires only on the first `READY` of a load.

## Testing

`./gradlew testDebugUnitTest detekt lint assembleDebug` — all pass. Three new `ServerAvailabilityTest` cases cover the sharing: concurrent checks share one *failing* ping, a later check starts a fresh one, and a caller that gives up doesn't cancel the answer the others are waiting on. The player and Home changes are in ViewModels whose collaborators (ExoPlayer, `JellyfinRepository`, `PlayerController`) aren't fakeable as constructed, so they're covered by review and manual reasoning rather than by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZD4g2mLAHrCvr1rsA2Cea