### PR TITLE
Sign debug builds with a shared keystore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # Only needed if the shared debug keystore uses non-default credentials; unset secrets come
+    # through empty and the build falls back to the standard debug key values.
+    env:
+      MIXTAPE_DEBUG_KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
+      MIXTAPE_DEBUG_KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
+      MIXTAPE_DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -42,6 +49,21 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+
+      # Signs debug APKs with the project's shared debug key so a build from here installs over
+      # a locally built one. Fork PRs don't get repository secrets, so the secret is optional and
+      # the build falls back to a runner-generated key when it's absent.
+      - name: Decode debug keystore
+        env:
+          DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$DEBUG_KEYSTORE_BASE64" ]; then
+            echo "::notice::DEBUG_KEYSTORE_BASE64 is not set; this APK is signed with a throwaway key and will not install over other builds."
+            exit 0
+          fi
+          keystore="$RUNNER_TEMP/debug.keystore"
+          printf '%s' "$DEBUG_KEYSTORE_BASE64" | base64 -d > "$keystore"
+          echo "MIXTAPE_DEBUG_KEYSTORE=$keystore" >> "$GITHUB_ENV"
 
       - name: Run Lint
         run: ./gradlew lint

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ local.properties
 
 .kotlin
 
+# Signing keys never belong in the repo. The shared debug keystore lives in a GitHub secret
+# (DEBUG_KEYSTORE_BASE64) and in a local file referenced by mixtape.debug.keystore.
+*.jks
+*.keystore
+
 # Local Claude Code state stays out of the repo, except the shared
 # session-start hook that provisions the Android SDK for Claude Code on the web.
 .claude/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,13 @@ Mixtape Haven is an Android application built with Kotlin and Jetpack Compose. T
 ./gradlew lint
 ```
 
+### Debug signing
+Debug builds are signed with a shared keystore so CI-built and locally built APKs can replace
+each other on a device. The keystore is not in the repo: CI decodes it from the
+`DEBUG_KEYSTORE_BASE64` secret, and local builds resolve it from `MIXTAPE_DEBUG_KEYSTORE` or the
+`mixtape.debug.keystore` Gradle property. When unset the build falls back to AGP's per-machine
+key and warns. See README.md > Debug signing.
+
 ## Architecture
 
 ### UI Layer

--- a/README.md
+++ b/README.md
@@ -82,6 +82,73 @@ Connect an Android device or start an emulator, then:
 
 Or use the **Run** button in Android Studio.
 
+## Debug signing
+
+By default Android Gradle Plugin signs debug builds with a keystore it generates per machine.
+That means an APK built on your laptop and an APK downloaded from a CI run carry different
+signatures, and Android refuses to install one over the other
+(`INSTALL_FAILED_UPDATE_INCOMPATIBLE`) — you have to uninstall first and lose app data.
+
+This project avoids that by pointing every debug build at one shared keystore. The keystore is
+**not** committed (this repo is public); it lives in a GitHub Actions secret for CI and in a
+local file on each machine.
+
+### One-time: create the keystore
+
+```bash
+keytool -genkeypair -v \
+  -keystore debug.keystore \
+  -storepass android -keypass android \
+  -alias androiddebugkey \
+  -keyalg RSA -keysize 2048 -validity 10950 \
+  -dname "CN=Android Debug,O=Android,C=US"
+```
+
+The standard debug credentials above are what the build assumes. If you use different ones, set
+them via the `MIXTAPE_DEBUG_KEYSTORE_PASSWORD`, `MIXTAPE_DEBUG_KEY_ALIAS` and
+`MIXTAPE_DEBUG_KEY_PASSWORD` environment variables (or the matching
+`mixtape.debug.key*` Gradle properties), and add them as the `DEBUG_KEYSTORE_PASSWORD`,
+`DEBUG_KEY_ALIAS` and `DEBUG_KEY_PASSWORD` repository secrets.
+
+Keep a backup of this file somewhere safe. If it is lost, a replacement key produces a different
+signature and everyone has to uninstall the app once.
+
+### Local setup
+
+Store the keystore outside the repository and point Gradle at it from
+`~/.gradle/gradle.properties`:
+
+```properties
+mixtape.debug.keystore=/absolute/path/to/debug.keystore
+```
+
+An `MIXTAPE_DEBUG_KEYSTORE` environment variable works too and takes precedence. If neither is
+set the build still works — it just falls back to the per-machine key and logs a warning, so
+those APKs won't install over anyone else's.
+
+### CI setup
+
+Add the keystore as a repository secret named `DEBUG_KEYSTORE_BASE64`:
+
+```bash
+base64 -w0 debug.keystore   # macOS: base64 -i debug.keystore
+```
+
+Paste the output into **Settings → Secrets and variables → Actions → New repository secret**.
+The workflow decodes it before building.
+
+Note that pull requests from forks do not receive repository secrets, so their APKs fall back to
+a throwaway key and won't install over a build from `main`. The workflow logs a notice when this
+happens.
+
+### Verifying which key signed an APK
+
+```bash
+$ANDROID_HOME/build-tools/<version>/apksigner verify --print-certs app-debug.apk
+```
+
+Two APKs are interchangeable when their `Signer #1 certificate SHA-256 digest` lines match.
+
 ## Build Commands
 
 ### Testing

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,28 @@ android.sourceSets.getByName("androidTest") {
     assets.srcDir("$projectDir/schemas")
 }
 
+// Debug signing settings come from the environment first (CI exports them after decoding the
+// keystore secret) and fall back to a Gradle property, so a local override can live in
+// ~/.gradle/gradle.properties instead of anywhere inside the repo.
+fun debugSigningSetting(envName: String, propertyName: String): String? =
+    providers.environmentVariable(envName)
+        .orElse(providers.gradleProperty(propertyName))
+        .orNull
+        ?.takeIf { it.isNotBlank() }
+
+val debugKeystorePath = debugSigningSetting("MIXTAPE_DEBUG_KEYSTORE", "mixtape.debug.keystore")
+val debugKeystore = debugKeystorePath?.let(::file)
+
+if (debugKeystore != null && !debugKeystore.isFile) {
+    // Falling back here would silently reintroduce the mismatched-signature problem this
+    // config exists to prevent, so a configured-but-missing keystore is a hard error.
+    error(
+        "Debug keystore not found at ${debugKeystore.absolutePath}. " +
+            "Fix or unset MIXTAPE_DEBUG_KEYSTORE / mixtape.debug.keystore. " +
+            "See README.md > Debug signing."
+    )
+}
+
 android {
     namespace = "pe.net.libre.mixtapehaven"
     compileSdk {
@@ -39,6 +61,40 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    signingConfigs {
+        // Without this, AGP signs debug builds with a keystore it generates per machine — and
+        // CI runners are a fresh machine every run — so an APK from a PR build cannot be
+        // installed over a locally built one (INSTALL_FAILED_UPDATE_INCOMPATIBLE), nor over an
+        // APK from the previous CI run. Pointing every build at one shared keystore keeps the
+        // signature stable. The keystore itself stays out of the repo; see README.md.
+        getByName("debug") {
+            if (debugKeystore != null) {
+                storeFile = debugKeystore
+                storePassword =
+                    debugSigningSetting(
+                        "MIXTAPE_DEBUG_KEYSTORE_PASSWORD",
+                        "mixtape.debug.keystore.password"
+                    ) ?: "android"
+                keyAlias =
+                    debugSigningSetting(
+                        "MIXTAPE_DEBUG_KEY_ALIAS",
+                        "mixtape.debug.key.alias"
+                    ) ?: "androiddebugkey"
+                keyPassword =
+                    debugSigningSetting(
+                        "MIXTAPE_DEBUG_KEY_PASSWORD",
+                        "mixtape.debug.key.password"
+                    ) ?: "android"
+            } else {
+                logger.lifecycle(
+                    "No shared debug keystore configured; using the auto-generated one. " +
+                        "APKs from this build may not install over APKs built elsewhere. " +
+                        "See README.md > Debug signing."
+                )
+            }
+        }
     }
 
     buildTypes {


### PR DESCRIPTION
## Problem

`app/build.gradle.kts` defined no `signingConfigs`, so debug builds fell back to the keystore AGP generates at `~/.android/debug.keystore`. That file is per-machine and created on first use — and CI runners are a fresh machine every run, since the workflow caches `~/.gradle` but not `~/.android`.

The result:

- An APK built locally can't be installed over one downloaded from CI (`INSTALL_FAILED_UPDATE_INCOMPATIBLE`) — you have to uninstall first and lose app data.
- Two consecutive CI runs also produce different signatures, so a PR APK can't be installed over the previous one. That undercuts the "download the APK from the PR comment and test it" flow the workflow advertises.

## Change

Point the debug signing config at a single shared keystore. The keystore is **not** committed — this repo is public — so it's resolved at build time:

- **CI** decodes it from a new `DEBUG_KEYSTORE_BASE64` repository secret into `$RUNNER_TEMP` and exports `MIXTAPE_DEBUG_KEYSTORE`.
- **Local builds** read `MIXTAPE_DEBUG_KEYSTORE`, or the `mixtape.debug.keystore` Gradle property (so the path can live in `~/.gradle/gradle.properties`, outside the repo).

Credentials default to the standard debug values (`android` / `androiddebugkey` / `android`) and are overridable via env vars or Gradle properties, with matching optional secrets wired up in the workflow.

Two fallback behaviours, deliberately different:

- **Nothing configured** → falls back to the generated key and logs a warning. Necessary because fork PRs don't receive repository secrets, and those builds must not fail.
- **Configured but the file is missing** → hard build error. Silently falling back there would quietly reintroduce the exact mismatch this change prevents.

`*.jks` / `*.keystore` are gitignored as a guard against committing a key by accident.

## Setup required after merge

This is inert until the secret exists. Create the keystore, then add it as `DEBUG_KEYSTORE_BASE64` under **Settings → Secrets and variables → Actions**, and point local builds at your copy. Full steps are in the new **Debug signing** section of `README.md`.

Note the one-time cost: the first build signed with the new key won't install over an app already on a device, so existing debug installs need a single uninstall.

## Verification

- `./gradlew assembleDebug` with no keystore configured → builds, warns.
- With a bad path configured → fails with an actionable message.
- `./gradlew detekt lint` → passing.
- Workflow YAML parses; base64 round-trip is byte-identical.
- A build using the CI-decoded keystore and a local build produced the **same** signer certificate — `1a32bff6…8dc68` via `apksigner verify --print-certs` — which is the property that was missing.

(The keystore used for testing was a throwaway generated in a scratch directory; it is not the one that should be used for the repository.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3VGrbJHvytY2fVRypPTMj)_