### PR TITLE
Release v1.1 as a signed APK the F-Droid metadata can point at

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+# Publishes the signed release APK as `app-release.apk` on the GitHub release for the tag.
+# F-Droid pulls exactly that URL — see the `Binaries:` field in fdroiddata's
+# metadata/pe.net.libre.mixtapehaven.yml — so both the asset name and the signing key are
+# load-bearing and are verified below before anything is uploaded.
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    env:
+      # SHA-256 of the release signing certificate, as printed by `apksigner verify
+      # --print-certs`. F-Droid pins this same value as AllowedAPKSigningKeys; an APK signed
+      # with any other key is rejected there and cannot update installs of earlier releases.
+      EXPECTED_SIGNING_CERT_SHA256: 03d74bfb5f0e87af50452ab3b44fce6f98dca919ea6b705e4bb8c469ca617abc
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # An unsigned or wrongly signed release is worse than no release at all, so a missing
+      # keystore fails the run rather than falling back to anything.
+      - name: Decode release keystore
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$RELEASE_KEYSTORE_BASE64" ]; then
+            echo "::error::RELEASE_KEYSTORE_BASE64 is not set; cannot produce a signed release."
+            exit 1
+          fi
+          keystore="$RUNNER_TEMP/release-keystore.jks"
+          printf '%s' "$RELEASE_KEYSTORE_BASE64" | base64 -d > "$keystore"
+          echo "MIXTAPE_RELEASE_KEYSTORE=$keystore" >> "$GITHUB_ENV"
+
+      - name: Build Release APK
+        env:
+          MIXTAPE_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          MIXTAPE_RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          MIXTAPE_RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: ./gradlew assembleRelease
+
+      # Everything below reads the built artifact rather than the build files, so it catches a
+      # stale versionName or a swapped keystore secret, not just a mistyped tag.
+      - name: Verify APK version and signing key
+        run: |
+          set -euo pipefail
+          apk=app/build/outputs/apk/release/app-release.apk
+          if [ ! -f "$apk" ]; then
+            echo "::error::$apk is missing. An unsigned build lands at app-release-unsigned.apk;"
+            echo "::error::check that the release signing secrets are set."
+            ls -l app/build/outputs/apk/release/ || true
+            exit 1
+          fi
+
+          build_tools=$(find "$ANDROID_HOME/build-tools" -maxdepth 1 -mindepth 1 -type d | sort -V | tail -1)
+          badging=$("$build_tools/aapt2" dump badging "$apk")
+          version_name=$(sed -n "s/.*versionName='\([^']*\)'.*/\1/p" <<< "$badging" | head -1)
+          version_code=$(sed -n "s/.*versionCode='\([^']*\)'.*/\1/p" <<< "$badging" | head -1)
+          expected_version="${GITHUB_REF_NAME#v}"
+
+          if [ "$version_name" != "$expected_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME expects versionName '$expected_version' but the APK reports '$version_name'."
+            echo "::error::Bump versionName/versionCode in app/build.gradle.kts and re-tag."
+            exit 1
+          fi
+
+          cert=$("$build_tools/apksigner" verify --print-certs "$apk" \
+            | sed -n 's/.*certificate SHA-256 digest: //p' | head -1)
+          if [ "$cert" != "$EXPECTED_SIGNING_CERT_SHA256" ]; then
+            echo "::error::APK is signed with $cert but F-Droid pins $EXPECTED_SIGNING_CERT_SHA256."
+            exit 1
+          fi
+
+          echo "Verified $expected_version (code $version_code), signed with $cert."
+          echo "VERSION_CODE=$version_code" >> "$GITHUB_ENV"
+
+      # `gh release create --notes-start-tag` fills in the changelog on first publish; on a
+      # re-run the release already exists and the APK is replaced in place.
+      - name: Publish APK to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          apk=app/build/outputs/apk/release/app-release.apk
+          if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+          fi
+          gh release upload "$GITHUB_REF_NAME" "$apk" --clobber
+
+      - name: Summarize
+        run: |
+          {
+            echo "### Released ${GITHUB_REF_NAME}"
+            echo
+            echo "- versionCode: \`${VERSION_CODE}\`"
+            echo "- APK: https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/app-release.apk"
+            echo
+            echo "Next: update \`metadata/pe.net.libre.mixtapehaven.yml\` in fdroiddata with this"
+            echo "versionName/versionCode and \`commit: ${GITHUB_REF_NAME}\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -149,6 +149,46 @@ $ANDROID_HOME/build-tools/<version>/apksigner verify --print-certs app-debug.apk
 
 Two APKs are interchangeable when their `Signer #1 certificate SHA-256 digest` lines match.
 
+## Release signing
+
+Release builds use a separate keystore from the debug one, configured the same way — an
+`MIXTAPE_RELEASE_KEYSTORE` environment variable or a `mixtape.release.keystore` Gradle property,
+with `MIXTAPE_RELEASE_KEYSTORE_PASSWORD`, `MIXTAPE_RELEASE_KEY_ALIAS` and
+`MIXTAPE_RELEASE_KEY_PASSWORD` for the credentials.
+
+There is no fallback here. When no release keystore is configured the signing config is absent
+and `assembleRelease` produces `app-release-unsigned.apk`, because F-Droid pins this app's
+signing certificate (`AllowedAPKSigningKeys` in
+[fdroiddata](https://gitlab.com/fdroid/fdroiddata)'s `metadata/pe.net.libre.mixtapehaven.yml`)
+and Android refuses to install an update signed by a different key. Losing this keystore means
+users must uninstall and reinstall, and F-Droid's metadata has to be updated.
+
+For CI, add the keystore and its credentials as the `RELEASE_KEYSTORE_BASE64`,
+`RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS` and `RELEASE_KEY_PASSWORD` repository secrets,
+the same way as the debug ones above.
+
+## Cutting a release
+
+1. Bump `versionCode` and `versionName` in `app/build.gradle.kts`. Both are literal values on
+   purpose: F-Droid rebuilds the app from source at the release tag and compares the result to
+   the published APK, so a version taken from the environment would not match.
+2. Add the release notes as `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`.
+   F-Droid displays this file as the changelog.
+3. Merge that to `main`, then tag it and push the tag:
+
+   ```bash
+   git tag v1.1
+   git push origin v1.1
+   ```
+
+The `Release` workflow then builds the signed APK, verifies that its version matches the tag and
+that it carries the expected signing certificate, and publishes it to the GitHub release as
+`app-release.apk` — the exact filename F-Droid downloads.
+
+Finally, update `metadata/pe.net.libre.mixtapehaven.yml` in fdroiddata with the new
+`versionName`, `versionCode`, `CurrentVersion` and `CurrentVersionCode`, and point the build at
+the tag (`commit: v1.1`) rather than a raw commit hash.
+
 ## Build Commands
 
 ### Testing

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,16 +25,16 @@ android.sourceSets.getByName("androidTest") {
     assets.srcDir("$projectDir/schemas")
 }
 
-// Debug signing settings come from the environment first (CI exports them after decoding the
+// Signing settings come from the environment first (CI exports them after decoding the
 // keystore secret) and fall back to a Gradle property, so a local override can live in
 // ~/.gradle/gradle.properties instead of anywhere inside the repo.
-fun debugSigningSetting(envName: String, propertyName: String): String? =
+fun signingSetting(envName: String, propertyName: String): String? =
     providers.environmentVariable(envName)
         .orElse(providers.gradleProperty(propertyName))
         .orNull
         ?.takeIf { it.isNotBlank() }
 
-val debugKeystorePath = debugSigningSetting("MIXTAPE_DEBUG_KEYSTORE", "mixtape.debug.keystore")
+val debugKeystorePath = signingSetting("MIXTAPE_DEBUG_KEYSTORE", "mixtape.debug.keystore")
 val debugKeystore = debugKeystorePath?.let(::file)
 
 if (debugKeystore != null && !debugKeystore.isFile) {
@@ -44,6 +44,17 @@ if (debugKeystore != null && !debugKeystore.isFile) {
         "Debug keystore not found at ${debugKeystore.absolutePath}. " +
             "Fix or unset MIXTAPE_DEBUG_KEYSTORE / mixtape.debug.keystore. " +
             "See README.md > Debug signing."
+    )
+}
+
+val releaseKeystorePath = signingSetting("MIXTAPE_RELEASE_KEYSTORE", "mixtape.release.keystore")
+val releaseKeystore = releaseKeystorePath?.let(::file)
+
+if (releaseKeystore != null && !releaseKeystore.isFile) {
+    error(
+        "Release keystore not found at ${releaseKeystore.absolutePath}. " +
+            "Fix or unset MIXTAPE_RELEASE_KEYSTORE / mixtape.release.keystore. " +
+            "See README.md > Release signing."
     )
 }
 
@@ -57,8 +68,11 @@ android {
         applicationId = "pe.net.libre.mixtapehaven"
         minSdk = 33
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        // F-Droid builds this file from source at the release tag and compares the result to the
+        // published APK, so the version must be literal here — deriving it from the environment
+        // would make an F-Droid build disagree with the binary it is verifying.
+        versionCode = 2
+        versionName = "1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -73,17 +87,17 @@ android {
             if (debugKeystore != null) {
                 storeFile = debugKeystore
                 storePassword =
-                    debugSigningSetting(
+                    signingSetting(
                         "MIXTAPE_DEBUG_KEYSTORE_PASSWORD",
                         "mixtape.debug.keystore.password"
                     ) ?: "android"
                 keyAlias =
-                    debugSigningSetting(
+                    signingSetting(
                         "MIXTAPE_DEBUG_KEY_ALIAS",
                         "mixtape.debug.key.alias"
                     ) ?: "androiddebugkey"
                 keyPassword =
-                    debugSigningSetting(
+                    signingSetting(
                         "MIXTAPE_DEBUG_KEY_PASSWORD",
                         "mixtape.debug.key.password"
                     ) ?: "android"
@@ -95,6 +109,31 @@ android {
                 )
             }
         }
+
+        // Unlike debug, there is no acceptable fallback key here: F-Droid pins this
+        // certificate as AllowedAPKSigningKeys, and Android will not install an update signed
+        // by anything else. With no keystore configured the config is simply absent and the
+        // release build stays unsigned, which the release workflow treats as a failure.
+        if (releaseKeystore != null) {
+            create("release") {
+                storeFile = releaseKeystore
+                storePassword =
+                    signingSetting(
+                        "MIXTAPE_RELEASE_KEYSTORE_PASSWORD",
+                        "mixtape.release.keystore.password"
+                    )
+                keyAlias =
+                    signingSetting(
+                        "MIXTAPE_RELEASE_KEY_ALIAS",
+                        "mixtape.release.key.alias"
+                    )
+                keyPassword =
+                    signingSetting(
+                        "MIXTAPE_RELEASE_KEY_PASSWORD",
+                        "mixtape.release.key.password"
+                    )
+            }
+        }
     }
 
     buildTypes {
@@ -104,6 +143,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.findByName("release")
         }
     }
     compileOptions {

--- a/fastlane/metadata/android/en-US/changelogs/2.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2.txt
@@ -1,0 +1,5 @@
+- Video player shows a buffering indicator instead of a frozen frame
+- Continue watching marks titles that can't play right now, and says why
+- Tapping the now playing notification reopens the app on the right screen
+- Fixed battery drain from wake locks and polling that kept running in the background
+- Debug builds are signed with a shared key so they install over each other


### PR DESCRIPTION
Unblocks the F-Droid inclusion request ([fdroiddata!33018](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/33018)), which was closed after sitting in `waiting-for-upstream` with no new release to review.

Two things were in the way. `v1.0` (2026-02-06) is still the only tag, and the commit its F-Droid build entry pins — `46557dda` — no longer exists in this repository, since `main`'s history was rewritten on 2026-03-14. An F-Droid build of the current metadata fails at checkout.

## Changes

**Version bump** — `versionCode` 1 → 2, `versionName` "1.0" → "1.1".

The version stays a literal in `app/build.gradle.kts` rather than being read from the environment. F-Droid rebuilds the app from source at the release tag and compares the result against the published APK, so an environment-supplied version would make the from-source build disagree with the binary it is verifying.

**Release signing** — a `release` signing config alongside the existing debug one, reading `MIXTAPE_RELEASE_KEYSTORE` / `mixtape.release.keystore` and matching credentials, following the same env-then-Gradle-property pattern.

Unlike debug, this has no fallback. F-Droid pins the certificate as `AllowedAPKSigningKeys` and Android refuses an update signed by a different key, so with no keystore configured the config is simply absent and `assembleRelease` produces `app-release-unsigned.apk` — which the workflow treats as a failure rather than publishing the wrong signature.

**`Release` workflow** (`.github/workflows/release.yml`) — triggers on a version tag, builds the signed APK, and publishes it to the GitHub release as `app-release.apk`, the exact filename F-Droid's `Binaries:` URL downloads.

Before uploading anything it reads the built artifact and checks that `versionName` matches the tag and that the signing certificate's SHA-256 matches the digest F-Droid pins. Reading the APK rather than the build files means a stale `versionName` or a swapped keystore secret is caught, not just a mistyped tag. Publishing uses `gh` from the runner, so no third-party actions are involved.

**Changelog** — `fastlane/metadata/android/en-US/changelogs/2.txt`, which F-Droid displays as the release notes.

**README** — new `Release signing` and `Cutting a release` sections, alongside the existing `Debug signing` one.

## Testing

`./gradlew assembleRelease detekt lint` and `./gradlew test` pass. With no keystore configured the build produces `app-release-unsigned.apk`, confirming the workflow's guard fires on exactly that case. `aapt2 dump badging` on the built APK reports `versionCode='2' versionName='1.1'`, and the workflow's parsing was verified against that output.

The signing and publishing path cannot be exercised here — it needs the release keystore — so the first real tag is the first end-to-end run.

## Follow-up (not in this PR)

Add the `RELEASE_KEYSTORE_BASE64`, `RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS` and `RELEASE_KEY_PASSWORD` repository secrets before tagging — the keystore must be the same one that signed v1.0, or F-Droid rejects the result.

After merging and pushing `v1.1`, the fdroiddata metadata needs `versionName: '1.1'`, `versionCode: 2`, `CurrentVersion`/`CurrentVersionCode` bumped, and `commit: v1.1` in place of the dead hash. Pinning the tag name rather than a raw hash keeps it working if history is ever rewritten again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBFysDbpcNW3eYCBqCrPRQ)_